### PR TITLE
[#33] Kakao iOS SDK 버전 2.22.5로 전환

### DIFF
--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
       .package(url: "https://github.com/Moya/Moya", branch: "master"),
       .package(url: "https://github.com/devxoul/Then", from: "3.0.0"),
       .package(url: "https://github.com/WenchaoD/FSCalendar", from: "2.8.3"),
-      .package(url: "https://github.com/kakao/kakao-ios-sdk", from: "2.22.5"),
+      .package(url: "https://github.com/kakao/kakao-ios-sdk", exact: "2.22.5"),
       .package(url: "https://github.com/onevcat/Kingfisher", from: "7.12.0"),
       .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "11.1.0"),
       .package(url: "https://github.com/google/GoogleAppMeasurement", from: "11.1.0"),


### PR DESCRIPTION
# 🍎 EATSSU iOS Team Pull Request

## 🔆 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- #33 를 조치했습니다.
- 해당 조치로 카카오앱으로 로그인이 될 지 안될지 모르겠습니다.
- 우선 디버깅을 위해 한 번 해보고, 후속조치 해보겠습니다.

## 💡 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 우선 버전만 바꾼 것이라서 바이패스로 바로 `qa` 브랜치까지 병합하겠습니다.

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #33 
