### PR TITLE
[#52] "문의하기" 외부 링크가 아닌, 카카오톡 앱으로 연결되도록 변경

### DIFF
--- a/EATSSU_MVC/EATSSU_MVC/Sources/Screen/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU_MVC/EATSSU_MVC/Sources/Screen/MyPage/ViewController/MyPageViewController.swift
@@ -15,6 +15,8 @@ import SnapKit
 import UIKit
 import Moya
 import Realm
+import KakaoSDKCommon
+import KakaoSDKTalk
 
 final class MyPageViewController: BaseViewController {
     
@@ -164,29 +166,50 @@ extension MyPageViewController: UITableViewDelegate {
         tableView.deselectRow(at: indexPath, animated: true)
       
       switch indexPath.row {
+      // "내가 쓴 리뷰" 스크린으로 이동
       case MyPageLabels.MyReview.rawValue:
             let myReviewViewController = MyReviewViewController()
             self.navigationController?.pushViewController(myReviewViewController, animated: true)
+      // "문의하기" 스크린으로 이동
       case MyPageLabels.Inquiry.rawValue:
-          if let kakaoChannelLink = URL(string: "http://pf.kakao.com/_ZlVAn") {
-            UIApplication.shared.open(kakaoChannelLink)
+        TalkApi.shared.chatChannel(channelPublicId: "_ZlVAn") { [weak self] error in
+          if error != nil {
+            if let kakaoChannelLink = URL(string: "http://pf.kakao.com/_ZlVAn") {
+              UIApplication.shared.open(kakaoChannelLink)
+            } else {
+              self?.showAlertController(title: "다시 시도하세요", message: "에러가 발생했습니다", style: .default)
+            }
+            /*
+             해야 할 일
+             - 채팅방에 진입하지 못했을 때, 앱에서 어떻게 처리해야 할 지 고민해야 합니다
+             - 지금은 웹으로 연결되게 조치해두었습니다만, 어떻게 해봐야 할 지 고민을 해봐야 한다고 생각합니다.
+             */
           } else {
-            showAlertController(title: "다시 시도하세요", message: "에러가 발생했습니다", style: .default)
+            /*
+             해야 할 일
+             - 정상적으로 코드가 동작할 때, 앱에서 처리해야 할 일이 있는지 확인
+             */
           }
+        }
+      // "서비스 이용약관" 스크린으로 이동
       case MyPageLabels.TermsOfUse.rawValue:
            let provisionViewController = ProvisionViewController(agreementType: .termsOfService)
             provisionViewController.navigationTitle = TextLiteral.termsOfUse
             self.navigationController?.pushViewController(provisionViewController, animated: true)
+      // "개인정보 이용약관" 스크린으로 이동
       case MyPageLabels.PrivacyTermsOfUse.rawValue:
             let provisionViewController = ProvisionViewController(agreementType: .privacyPolicy)
             provisionViewController.navigationTitle = TextLiteral.privacyTermsOfUse
             self.navigationController?.pushViewController(provisionViewController, animated: true)
+      // "로그아웃" 팝업알림 표시
       case MyPageLabels.Logout.rawValue:
         self.logoutShowAlert()
+      // "탈퇴하기" 스크린으로 이동
       case MyPageLabels.Withdraw.rawValue:
            let userWithdrawViewController = UserWithdrawViewController()
             userWithdrawViewController.getUsernickName(nickName: self.nickName)
             self.navigationController?.pushViewController(userWithdrawViewController, animated: true)
+      // "만든사람들" 스크린으로 이동
       case MyPageLabels.Creator.rawValue:
         let creatorViewController = CreatorViewController()
         navigationController?.pushViewController(creatorViewController, animated: true)

--- a/EATSSU_MVC/EATSSU_MVC/Sources/Utility/Namespace/MyPageLabels.swift
+++ b/EATSSU_MVC/EATSSU_MVC/Sources/Utility/Namespace/MyPageLabels.swift
@@ -7,13 +7,30 @@
 
 import Foundation
 
+/// "마이파이지"에서 확인할 수 있는 서비스 리스트
 enum MyPageLabels : Int {
+  
+  /// 내가 쓴 리뷰
   case MyReview = 0
+  
+  /// 문의하기
   case Inquiry
+  
+  /// 서비스 이용약관
   case TermsOfUse
+  
+  /// 개인정보 이용약관
   case PrivacyTermsOfUse
+  
+  /// 로그아웃
   case Logout
+  
+  /// 탈퇴하기
   case Withdraw
+  
+  /// 만든사람들
   case Creator
+  
+  /// 앱버전
   case AppVersion
 }

--- a/EATSSU_MVC/Project.swift
+++ b/EATSSU_MVC/Project.swift
@@ -71,16 +71,23 @@ let project = Project(
               .external(name: "Moya", condition: .none),
               .external(name: "Then", condition: .none),
               .external(name: "FSCalendar", condition: .none),
-              .external(name: "KakaoSDKAuth", condition: .none),
-              .external(name: "KakaoSDKUser", condition: .none),
-              .external(name: "KakaoSDKCommon", condition: .none),
               .external(name: "Kingfisher", condition: .none),
-              .external(name: "FirebaseCrashlytics", condition: .none),
-              .external(name: "FirebaseAnalytics", condition: .none),
-              .external(name: "FirebaseRemoteConfig", condition: .none),
               .external(name: "GoogleAppMeasurement", condition: .none),
               .external(name: "Realm", condition: .none),
               .external(name: "RealmSwift", condition: .none),
+              
+              // Firebase Module
+              .external(name: "FirebaseCrashlytics", condition: .none),
+              .external(name: "FirebaseAnalytics", condition: .none),
+              .external(name: "FirebaseRemoteConfig", condition: .none),
+              
+              // KakakSDK Module
+              .external(name: "KakaoSDKAuth", condition: .none),
+              .external(name: "KakaoSDKUser", condition: .none),
+              .external(name: "KakaoSDKCommon", condition: .none),
+              .external(name: "KakaoSDKTalk", condition: .none),
+              
+              // EATSSU Module
               .project(target: "EATSSUComponents", path:.relativeToRoot("../EATSSUComponents"), condition: .none)
             ],
             settings: eatSSUSettings


### PR DESCRIPTION
# 🍎 EATSSU iOS Team Pull Request

## 🔆 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 카카오 SDK를 사용해서 바로 채팅방으로 연결될 수 있도록 설계했습니다.
- 만약 카카오톡이 없는 디바이스인 경우, 기존 그대로 웹링크로 연결되게 설계했습니다.

## 💡 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 시뮬레이터에 카카오톡을 설치할 수 없어서 테스트 플라이트에서 실행결과를 확인해봐야 합니다.
- 우선 카카오톡이 없는 시나리오에서 웹링크가 열리도록 설계했습니다.

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

![Simulator Screen Recording - iPhone 16 Pro - 2024-09-18 at 23 17 29](https://github.com/user-attachments/assets/69a09453-c2c5-4a84-9dd5-25f93feff2a5)

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #52 
