### PR TITLE
[v2.1.0.3] Info.plist에 누락된 kakaoplus 값을 넣고 테스트

### DIFF
--- a/EATSSU_MVC/EATSSU_MVC/Sources/Screen/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU_MVC/EATSSU_MVC/Sources/Screen/MyPage/ViewController/MyPageViewController.swift
@@ -172,9 +172,9 @@ extension MyPageViewController: UITableViewDelegate {
             self.navigationController?.pushViewController(myReviewViewController, animated: true)
       // "문의하기" 스크린으로 이동
       case MyPageLabels.Inquiry.rawValue:
-        TalkApi.shared.chatChannel(channelPublicId: "_ZlVAn") { [weak self] error in
+        TalkApi.shared.chatChannel(channelPublicId: TextLiteral.KakaoChannel.id) { [weak self] error in
           if error != nil {
-            if let kakaoChannelLink = URL(string: "http://pf.kakao.com/_ZlVAn") {
+            if let kakaoChannelLink = URL(string: "http://pf.kakao.com/\(TextLiteral.KakaoChannel.id)") {
               UIApplication.shared.open(kakaoChannelLink)
             } else {
               self?.showAlertController(title: "다시 시도하세요", message: "에러가 발생했습니다", style: .default)

--- a/EATSSU_MVC/EATSSU_MVC/Sources/Utility/Literal/TextLiteral.swift
+++ b/EATSSU_MVC/EATSSU_MVC/Sources/Utility/Literal/TextLiteral.swift
@@ -25,6 +25,12 @@ enum TextLiteral {
     /// 오늘의 학식을 확인해보세요!
     static let dailyWeekdayNotificationBody: String = "오늘의 학식을 확인해보세요!"
   }
+  
+  enum KakaoChannel {
+    
+    /// EATSSU 카카오 채널 ID
+    static let id: String = "_ZlVAn"
+  }
 
     
     // MARK: - Sign In

--- a/EATSSU_MVC/Project.swift
+++ b/EATSSU_MVC/Project.swift
@@ -10,7 +10,12 @@ let eatSSUInfoPlist: InfoPlist = .extendingDefault(with: [
           "CFBundleURLSchemes": ["kakao$(KAKAO_API_KEY)"]
       ]
   ],
-  "LSApplicationQueriesSchemes": ["kakaokompassauth", "kakaolink"],
+  "LSApplicationQueriesSchemes": [
+    "kakaokompassauth",
+    "kakaolink",
+    "kakaoplus",
+    "kakaotalk"
+  ],
   "NSAppTransportSecurity": [
       "NSAllowsArbitraryLoads": true
   ],


### PR DESCRIPTION
# 🍎 EATSSU iOS Team Pull Request

## 🔆 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 공식문서에서 언급한 kakaoplus 값을 Info.plist에 넣었을 때, 정상적으로 카카오톡 채팅방으로 연결되는지 확인합니다.

## 💡 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 없습니다.

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

- 없습니다.

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #77 
