### PR TITLE
[#111] 푸시 알림 사용자 스위치 저장 중 알림 해제가 서비스에 반영이 되지 않는 문제

### DIFF
--- a/EATSSU_MVC/EATSSU_MVC/Sources/Notification/NotificationManager.swift
+++ b/EATSSU_MVC/EATSSU_MVC/Sources/Notification/NotificationManager.swift
@@ -56,11 +56,13 @@ class NotificationManager {
 
 	/// 평일 11시에 앱의 유입을 유도하는 푸시 알림을 취소하는 메소드
 	func cancelWeekday11AMNotification() {
-		let weekday = [2, 3, 4, 5, 6]
-		let identifier = "weekdayNotification-\(weekday)"
+		let weekdays = [2, 3, 4, 5, 6]
 
-		let center = UNUserNotificationCenter.current()
-		center.removePendingNotificationRequests(withIdentifiers: [identifier])
+		for weekday in weekdays {
+			let identifier = "weekdayNotification-\(weekday)"
+			let center = UNUserNotificationCenter.current()
+			center.removePendingNotificationRequests(withIdentifiers: [identifier])
+		}
 	}
 
 	/// 앱 실행 시 알림 발송 권한을 요청하는 팝업 호출 메소드

--- a/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -146,7 +146,7 @@ extension MyPageViewController: UITableViewDataSource {
 			
 			NotificationManager.shared.checkNotificationSetting { setting in
 				switch setting.authorizationStatus {
-				case .authorized,.notDetermined, .provisional, .ephemeral:
+				case .authorized, .notDetermined, .provisional, .ephemeral:
 					DispatchQueue.main.async {
 						cell.toggleSwitch.setOn(self.switchState, animated: true)
 					}


### PR DESCRIPTION
# 🍎 EATSSU iOS Team Pull Request

## 🔆 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 알림 해제 로직에서 정말 간단한 에러가 있었습니다.
- 로직 상 정말 단순한데, 이걸 왜 놓쳤나 싶습니다....어휴 바보

## 💡 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 코드 보면 쉽게 이해할 수 있을 것 입니다.

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #111 
