### PR TITLE
[#119] 메뉴 cell 레이아웃 수정

### DIFF
--- a/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Home/Enum/MenuTypeInfo.swift
+++ b/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Home/Enum/MenuTypeInfo.swift
@@ -10,13 +10,4 @@ import Foundation
 enum MenuTypeInfo {
     case change(ChangeMenuTableResponse)
     case fix(MenuInformation)
-    
-//    var menuData: MenuType {
-//        switch self {
-//        case .change(let menuData):
-//            return menuData
-//        case .fix(let menuData):
-//            return menuData
-//        }
-//    }
 }

--- a/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Home/View/RestaurantTableView/RestaurantTableViewMenuCell.swift
+++ b/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Home/View/RestaurantTableView/RestaurantTableViewMenuCell.swift
@@ -24,9 +24,9 @@ class RestaurantTableViewMenuCell: BaseTableViewCell {
     
     // MARK: - UI Components
     private let contentStackView = UIStackView()
-    private let nameLabel = UILabel()
-    private let priceLabel = UILabel()
-    private let ratingLabel = UILabel()
+    private var nameLabel = UILabel()
+    private var priceLabel = UILabel()
+    private var ratingLabel = UILabel()
     
     // MARK: - Life Cycle
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -48,29 +48,27 @@ class RestaurantTableViewMenuCell: BaseTableViewCell {
     // MARK: - Functions
     override func configureUI() {
         contentView.addSubview(contentStackView)
-        contentStackView.addSubviews(nameLabel,
-                                priceLabel,
-                                ratingLabel)
+        contentStackView.addArrangedSubviews([nameLabel,
+                                            priceLabel,
+                                            ratingLabel])
+//        contentStackView.backgroundColor = .yellow
+//        contentView.backgroundColor = .green
     }
 
     override func setLayout() {
         contentStackView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(11)
             $0.horizontalEdges.equalToSuperview().inset(12)
+            $0.bottom.equalToSuperview().inset(5)
         }
         nameLabel.snp.makeConstraints {
-            $0.top.equalTo(contentView.snp.top).offset(11)
             $0.width.equalTo(210)
-            $0.bottom.equalTo(contentView.snp.bottom).offset(-5)
         }
         priceLabel.snp.makeConstraints {
-            $0.leading.equalTo(nameLabel.snp.trailing)
-            $0.width.equalTo(60)
-            $0.centerY.equalTo(nameLabel)
+            $0.width.equalTo(47)
         }
         ratingLabel.snp.makeConstraints {
-            $0.trailing.equalTo(contentView.snp.trailing).inset(28)
-            $0.width.equalTo(30)
-            $0.centerY.equalTo(nameLabel)
+            $0.width.equalTo(25)
         }
     }
 }
@@ -80,19 +78,23 @@ extension RestaurantTableViewMenuCell {
         contentStackView.do {
             $0.axis = .horizontal
             $0.alignment = .center
+            $0.spacing = 24
         }
         nameLabel.do {
             $0.font = .body3
             $0.numberOfLines = 0
             $0.lineBreakMode = .byWordWrapping
+//            $0.backgroundColor = .red
         }
         priceLabel.do {
             $0.font = .body3
             $0.textAlignment = .center
+//            $0.backgroundColor = .blue
         }
         ratingLabel.do {
             $0.font = .body3
             $0.textAlignment = .center
+//            $0.backgroundColor = .green
         }
     }
     
@@ -105,7 +107,7 @@ extension RestaurantTableViewMenuCell {
                 let formatRating = String(format: "%.1f", data.mainRating ?? 0)
                 ratingLabel.text = formatRating
             } else {
-                ratingLabel.text = TextLiteral.emptyRating
+                ratingLabel.text = TextLiteral.Home.emptyRating
             }
             
             if data.menusInformationList.isEmpty {

--- a/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Home/View/RestaurantTableView/RestaurantTableViewMenuCell.swift
+++ b/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Home/View/RestaurantTableView/RestaurantTableViewMenuCell.swift
@@ -51,8 +51,6 @@ class RestaurantTableViewMenuCell: BaseTableViewCell {
         contentStackView.addArrangedSubviews([nameLabel,
                                             priceLabel,
                                             ratingLabel])
-//        contentStackView.backgroundColor = .yellow
-//        contentView.backgroundColor = .green
     }
 
     override func setLayout() {
@@ -84,17 +82,14 @@ extension RestaurantTableViewMenuCell {
             $0.font = .body3
             $0.numberOfLines = 0
             $0.lineBreakMode = .byWordWrapping
-//            $0.backgroundColor = .red
         }
         priceLabel.do {
             $0.font = .body3
             $0.textAlignment = .center
-//            $0.backgroundColor = .blue
         }
         ratingLabel.do {
             $0.font = .body3
             $0.textAlignment = .center
-//            $0.backgroundColor = .green
         }
     }
     

--- a/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Home/View/RestaurantTableView/RestaurantTableViewMenuTitleCell.swift
+++ b/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Home/View/RestaurantTableView/RestaurantTableViewMenuTitleCell.swift
@@ -16,18 +16,23 @@ class RestaurantTableViewMenuTitleCell: BaseTableViewCell {
     // MARK: - UI Components
     
     private let nameLabel = UILabel().then {
-        $0.text = TextLiteral.menu
+        $0.text = TextLiteral.Home.todayMenu
         $0.font = .body2
+//        $0.backgroundColor = .red
     }
     
     private let priceLabel = UILabel().then {
-        $0.text = TextLiteral.price
+        $0.text = TextLiteral.Home.price
         $0.font = .body2
+        $0.textAlignment = .center
+//        $0.backgroundColor = .blue
     }
     
     private let ratingLabel = UILabel().then {
-        $0.text = TextLiteral.rating
+        $0.text = TextLiteral.Home.rating
         $0.font = .body2
+        $0.textAlignment = .center
+//        $0.backgroundColor = .green
     }
     
     private let lineView = UIView().then {
@@ -39,7 +44,8 @@ class RestaurantTableViewMenuTitleCell: BaseTableViewCell {
                                 priceLabel, 
                                 ratingLabel])
         $0.axis = .horizontal
-        $0.setCustomSpacing(35, after: priceLabel)
+        $0.alignment = .center
+        $0.spacing = 24
     }
     
     // MARK: - Functions
@@ -52,12 +58,20 @@ class RestaurantTableViewMenuTitleCell: BaseTableViewCell {
     
     override func setLayout() {
         infoTableStackView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(15)
-            $0.leading.equalToSuperview().inset(15)
-            $0.trailing.equalToSuperview().inset(32)
+            $0.top.equalToSuperview().offset(18)
+            $0.horizontalEdges.equalToSuperview().inset(12)
+        }
+        nameLabel.snp.makeConstraints {
+            $0.width.equalTo(210)
+        }
+        priceLabel.snp.makeConstraints {
+            $0.width.equalTo(47)
+        }
+        ratingLabel.snp.makeConstraints {
+            $0.width.equalTo(25)
         }
         lineView.snp.makeConstraints {
-            $0.top.equalTo(infoTableStackView.snp.bottom).offset(10)
+            $0.top.equalTo(infoTableStackView.snp.bottom).offset(11)
             $0.horizontalEdges.equalToSuperview().inset(8)
             $0.height.equalTo(1)
             $0.bottom.equalToSuperview()

--- a/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Home/View/RestaurantTableView/RestaurantTableViewMenuTitleCell.swift
+++ b/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Home/View/RestaurantTableView/RestaurantTableViewMenuTitleCell.swift
@@ -18,21 +18,18 @@ class RestaurantTableViewMenuTitleCell: BaseTableViewCell {
     private let nameLabel = UILabel().then {
         $0.text = TextLiteral.Home.todayMenu
         $0.font = .body2
-//        $0.backgroundColor = .red
     }
     
     private let priceLabel = UILabel().then {
         $0.text = TextLiteral.Home.price
         $0.font = .body2
         $0.textAlignment = .center
-//        $0.backgroundColor = .blue
     }
     
     private let ratingLabel = UILabel().then {
         $0.text = TextLiteral.Home.rating
         $0.font = .body2
         $0.textAlignment = .center
-//        $0.backgroundColor = .green
     }
     
     private let lineView = UIView().then {

--- a/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Home/ViewController/HomeRestaurantViewController.swift
+++ b/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Home/ViewController/HomeRestaurantViewController.swift
@@ -176,8 +176,10 @@ extension HomeRestaurantViewController: UITableViewDataSource {
             let cell = tableView.dequeueReusableCell(withIdentifier: RestaurantTableViewMenuTitleCell.identifier, for: indexPath)
             cell.selectionStyle = .none
             return cell
+        }
+        
         /// Menu Cell
-        } else {
+        else {
             let cell = tableView.dequeueReusableCell(withIdentifier: RestaurantTableViewMenuCell.identifier, for: indexPath) as! RestaurantTableViewMenuCell
             // MARK: 섹션지정
             if indexPath.section == 0 {

--- a/EATSSU_MVC/EATSSU_MVC/Sources/Utility/Literal/TextLiteral.swift
+++ b/EATSSU_MVC/EATSSU_MVC/Sources/Utility/Literal/TextLiteral.swift
@@ -48,12 +48,26 @@ enum TextLiteral {
     static let completeLabel: String = "완료하기"
 
 	// MARK: - Home
-		
-	static let menu: String = "오늘의 메뉴"
-	static let price: String = "가격"
-	static let rating: String = "평점"
-	static let emptyRating: String = "  -"
-		
+    
+    enum Home {
+        
+        /// 오늘의 메뉴
+        static let todayMenu: String = "오늘의 메뉴"
+        
+        /// 가격
+        static let price: String = "가격"
+        
+        /// 평점
+        static let rating: String = "평점"
+        
+        /// -
+        static let emptyRating: String = "  -"
+        
+        /// 제공되는 메뉴가 없습니다
+        static let noMenuProvidedMessage: String = "제공되는 메뉴가 없습니다"
+
+    }
+				
 	// MARK: - Restaurant
 		
 	static let dormitoryRestaurant: String = "기숙사 식당"


### PR DESCRIPTION
# 🍎 EATSSU iOS Team Pull Request

## 🔆 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 메인 뷰의 테이블 셀 레이아웃 수정하였습니다.

## 💡 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 현재 red:`RestaurantTableViewMenuTitleCell` / blue:`RestaurantTableViewMenuCell` 셀을 커스텀하여 재사용하고 있습니다.
- 두 부분의 레이아웃이 같아 하나의 셀만 선언하여 재사용하려 했으나 두 영역의 font가 다르더라구요. 따라서 현재 아래와 같이 구현한 상황인데 더 좋은 방법이 있을지 고민중입니다.
<img width="441" alt="image" src="https://github.com/user-attachments/assets/e0473d3e-6854-4a50-a441-c2c77bd5dd58">




## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
<img width="392" alt="image" src="https://github.com/user-attachments/assets/2bd0ee69-36fc-4f03-9973-5760e5e40d9f">
<img width="404" alt="스크린샷 2024-09-27 오후 1 58 50" src="https://github.com/user-attachments/assets/20cd6269-0c74-4115-a5ec-487cc97ce99d">


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #119
