### PR TITLE
[#38] 리뷰 신고 페이지의 제목 문구가 완성되지 않는 문제 해결 및 좌측 정렬 속성 추가

### DIFF
--- a/EATSSUComponents/EATSSUComponents/Sources/UIComponents/ReportButton/ESReportButton.swift
+++ b/EATSSUComponents/EATSSUComponents/Sources/UIComponents/ReportButton/ESReportButton.swift
@@ -72,6 +72,9 @@ final public class ESReportButton: UIButton {
     self.setTitle(title, for: .normal)
     self.setTitleColor(.black, for: .normal)
     self.titleLabel?.font = EATSSUComponentsFontFamily.Pretendard.medium.font(size: 14)
+      self.contentHorizontalAlignment = UIControl.ContentHorizontalAlignment.left
+      // TODO: Deprecated. UIButtonConfiguration 속성 사용할 경우 해당사항 적용안됨 / Configuration 속성으로 수정 필요
+      self.titleEdgeInsets = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 0)
   }
   
   private func setupButton() {

--- a/EATSSUComponents/EATSSUComponents/Sources/UIComponents/ReportButton/ESReportButton.swift
+++ b/EATSSUComponents/EATSSUComponents/Sources/UIComponents/ReportButton/ESReportButton.swift
@@ -13,89 +13,89 @@ import UIKit
 import SnapKit
 
 final public class ESReportButton: UIButton {
-  
-  // MARK: - Properties
-
-  public override var isSelected: Bool {
-    didSet {
-      updateButtonAppearance()
+    
+    // MARK: - Properties
+    
+    public override var isSelected: Bool {
+        didSet {
+            updateButtonAppearance()
+        }
     }
-  }
-  
-  // MARK: - Intializer
-  
-   /// Swift 이니셜라이저 다형성, 지정 이니셜라이저, 편의 이니셜라이저 사용성에 관한 메모
-   /// - 지정 연산자를 오버라이딩 하는지 여부에 따라서 설계할 수 있는 이니셜라이저가 다르다.
-  
-  /// 지정 이니셜라이저 (Designated Intializer)를 오버라이딩 하는 경우 아래의 코드와 같은 형식으로 설계한다.
-  /// self.init를 사용했다는 것이 중요하다.
-  /// 해당 클래스 안에 지정 연산자를 오버라이딩 했기 때문에 super.init이 아니라 self.init을 사용해야 한다.
-  
-  /*
-  public convenience init(title: String) {
-    self.init(frame: .zero)
-    self.setProperties(title: title)
-  }
-  
-  override public init(frame: CGRect) {
-    super.init(frame: frame)
-  }
-   */
-  
-  /// 지정 이니셜라이저 (Designated Intializer)를 오버라이딩 하지 않으면, 단순 호출만 하면 되는 것이기 때문에,
-  /// 아래와 같이 코드를 설계한다.
-  /// super.init을 사용했다는 것이 중요하다.
-  /// 지정 이니셜라이저를 오버라이딩 하지 않았기 떄문에, 이니셜라이저를 직접 설계하고 super.init 지정 이니셜라이저를 호출하면 된다.
-  
-  /// 회색 컬러의 ReportButton
-  ///
-  /// - Parameter title: 버튼 타이틀
-  public init(title: String) {
-    super.init(frame: .zero)
-    self.setProperties(title: title)
-    self.setupButton()
-  }
-
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-  
-  // MARK: - Methods
-
-  private func setProperties(title: String) {
-    self.backgroundColor = .white
     
-    self.layer.borderWidth = 1
-    self.layer.borderColor = EATSSUComponentsAsset.Colors.GrayScaleColor.gray300.color.cgColor
-    self.layer.cornerRadius = 10
+    // MARK: - Intializer
     
-    self.setTitle(title, for: .normal)
-    self.setTitleColor(.black, for: .normal)
-    self.titleLabel?.font = EATSSUComponentsFontFamily.Pretendard.medium.font(size: 14)
-      self.contentHorizontalAlignment = UIControl.ContentHorizontalAlignment.left
-      // TODO: Deprecated. UIButtonConfiguration 속성 사용할 경우 해당사항 적용안됨 / Configuration 속성으로 수정 필요
-      self.titleEdgeInsets = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 0)
-  }
-  
-  private func setupButton() {
-    self.updateButtonAppearance()
+    /// Swift 이니셜라이저 다형성, 지정 이니셜라이저, 편의 이니셜라이저 사용성에 관한 메모
+    /// - 지정 연산자를 오버라이딩 하는지 여부에 따라서 설계할 수 있는 이니셜라이저가 다르다.
     
-    self.addTarget(self, action: #selector(esReportButtonTapped), for: .touchUpInside)
-  }
-  
-  @objc
-  private func esReportButtonTapped() {
-    self.isSelected.toggle()
-    self.updateButtonAppearance()
-  }
-  
-  private func updateButtonAppearance() {
-    if self.isSelected {
-      self.backgroundColor = EATSSUComponentsAsset.Colors.MainColor.secondary.color
-      self.layer.borderColor = EATSSUComponentsAsset.Colors.MainColor.primary.color.cgColor
-    } else {
-      self.backgroundColor = .white
-      self.layer.borderColor = EATSSUComponentsAsset.Colors.GrayScaleColor.gray300.color.cgColor
+    /// 지정 이니셜라이저 (Designated Intializer)를 오버라이딩 하는 경우 아래의 코드와 같은 형식으로 설계한다.
+    /// self.init를 사용했다는 것이 중요하다.
+    /// 해당 클래스 안에 지정 연산자를 오버라이딩 했기 때문에 super.init이 아니라 self.init을 사용해야 한다.
+    
+    /*
+     public convenience init(title: String) {
+     self.init(frame: .zero)
+     self.setProperties(title: title)
+     }
+     
+     override public init(frame: CGRect) {
+     super.init(frame: frame)
+     }
+     */
+    
+    /// 지정 이니셜라이저 (Designated Intializer)를 오버라이딩 하지 않으면, 단순 호출만 하면 되는 것이기 때문에,
+    /// 아래와 같이 코드를 설계한다.
+    /// super.init을 사용했다는 것이 중요하다.
+    /// 지정 이니셜라이저를 오버라이딩 하지 않았기 떄문에, 이니셜라이저를 직접 설계하고 super.init 지정 이니셜라이저를 호출하면 된다.
+    
+    /// 회색 컬러의 ReportButton
+    ///
+    /// - Parameter title: 버튼 타이틀
+    public init(title: String) {
+        super.init(frame: .zero)
+        self.setProperties(title: title)
+        self.setupButton()
     }
-  }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Methods
+    
+    private func setProperties(title: String) {
+        self.backgroundColor = .white
+        
+        self.layer.borderWidth = 1
+        self.layer.borderColor = EATSSUComponentsAsset.Colors.GrayScaleColor.gray300.color.cgColor
+        self.layer.cornerRadius = 10
+        
+        self.setTitle(title, for: .normal)
+        self.setTitleColor(.black, for: .normal)
+        self.titleLabel?.font = EATSSUComponentsFontFamily.Pretendard.medium.font(size: 14)
+        self.contentHorizontalAlignment = UIControl.ContentHorizontalAlignment.left
+        // TODO: Deprecated. UIButtonConfiguration 속성 사용할 경우 해당사항 적용안됨 / Configuration 속성으로 수정 필요
+        self.titleEdgeInsets = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 0)
+    }
+    
+    private func setupButton() {
+        self.updateButtonAppearance()
+        
+        self.addTarget(self, action: #selector(esReportButtonTapped), for: .touchUpInside)
+    }
+    
+    @objc
+    private func esReportButtonTapped() {
+        self.isSelected.toggle()
+        self.updateButtonAppearance()
+    }
+    
+    private func updateButtonAppearance() {
+        if self.isSelected {
+            self.backgroundColor = EATSSUComponentsAsset.Colors.MainColor.secondary.color
+            self.layer.borderColor = EATSSUComponentsAsset.Colors.MainColor.primary.color.cgColor
+        } else {
+            self.backgroundColor = .white
+            self.layer.borderColor = EATSSUComponentsAsset.Colors.GrayScaleColor.gray300.color.cgColor
+        }
+    }
 }

--- a/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Review/View/RerportView/ReportView.swift
+++ b/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Review/View/RerportView/ReportView.swift
@@ -103,7 +103,6 @@ final class ReportView: BaseUIView {
   internal override func setLayout() {
     reviewReportReasonLabel.snp.makeConstraints { make in
       make.leading.equalTo(self).inset(24)
-      make.trailing.equalTo(self).inset(166)
       make.top.equalTo(safeAreaLayoutGuide.snp.top)
     }
     

--- a/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Review/View/RerportView/ReportView.swift
+++ b/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Review/View/RerportView/ReportView.swift
@@ -15,151 +15,151 @@ import SnapKit
 import EATSSUComponents
 
 final class ReportView: BaseUIView {
-  
-  // MARK: - UI Components
-  
-  /// "리뷰 신고 사유를 알려주세요" 레이블
-  private let reviewReportReasonLabel: UILabel = {
-    let label = UILabel()
-    label.text = "리뷰 신고 사유를 알려주세요"
-    label.font = EATSSUFontFamily.Pretendard.bold.font(size: 18)
-    label.textColor = .black
-    return label
-  }()
-  
-  /// "하나의 리뷰에 대해 24시간 내 한 번만 신고 가능합니다." 레이블
-  private let singleReportPerDayLabel: UILabel = {
-    let label = UILabel()
-    label.text = "하나의 리뷰에 대해 24시간 내 한 번만 신고 가능합니다."
-    label.font = EATSSUFontFamily.Pretendard.regular.font(size: 12)
-    label.textColor = EATSSUAsset.Color.GrayScale.gray600.color
-    return label
-  }()
-  
-  /// "메뉴와 관련없는 내용" 버튼
-  internal let unrelatedToMenuButton = ESReportButton(title: "메뉴와 관련없는 내용")
-  
-  /// "음란성, 욕설 등 부적절한 내용" 버튼
-  internal let inappropriateContentButton = ESReportButton(title: "음란성, 욕설 등 부적절한 내용")
-  
-  /// " 부적절한 홍보 또는 광고" 버튼
-  internal let inappropriatePromotionButton = ESReportButton(title: "부적절한 홍보 또는 광고")
-  
-  /// "리뷰 작성 취지에 맞지 않는 내용 (복사글 등)" 버튼
-  internal let offTopicContentButton = ESReportButton(title: "리뷰 작성 취지에 맞지 않는 내용 (복사글 등)")
-  
-  /// "저작권 도용 의심 (사진 등)" 버튼
-  internal let copyrightInfringementButton = ESReportButton(title: "저작권 도용 의심 (사진 등)")
-  
-  /// "기타 (하단 내용 작성)" 버튼
-  internal let otherReasonButton = ESReportButton(title: "기타 (하단 내용 작성)")
-  
-  /// "리뷰 신고 사유를 작성해 주세요" 텍스트필드
-  internal var reviewReportReasonTextView: UITextView = {
-    let textView = UITextView()
-    textView.font = EATSSUFontFamily.Pretendard.medium.font(size: 16)
-    textView.layer.cornerRadius = 10
-    textView.backgroundColor = EATSSUAsset.Color.GrayScale.gray100.color
-    textView.layer.borderWidth = 1
-    textView.layer.borderColor =  EATSSUAsset.Color.GrayScale.gray200.color.cgColor
-    textView.textContainerInset = UIEdgeInsets(top: 16.0, left: 16.0, bottom: 16.0, right: 16.0)
-    textView.isEditable = false
-    return textView
-  }()
-  
-  /// 0 / 300 와 같이 현재 작성된 글자 수 상태 레이블
-  internal var characterCountLabel: UILabel = {
-    let label = UILabel()
-    label.text = "0 / 300"
-    label.font = EATSSUFontFamily.Pretendard.regular.font(size: 12)
-    label.textColor = EATSSUAsset.Color.GrayScale.gray400.color
-    return label
-  }()
-  
-  /// "EAT SSU 팀에게 보내기" 버튼
-  internal let sendToEATSSUButton = ESButton(size: .big, title: "EAT SSU 팀에게 보내기")
-  
-  // MARK: - Functions
+    
+    // MARK: - UI Components
+    
+    /// "리뷰 신고 사유를 알려주세요" 레이블
+    private let reviewReportReasonLabel: UILabel = {
+        let label = UILabel()
+        label.text = "리뷰 신고 사유를 알려주세요"
+        label.font = EATSSUFontFamily.Pretendard.bold.font(size: 18)
+        label.textColor = .black
+        return label
+    }()
+    
+    /// "하나의 리뷰에 대해 24시간 내 한 번만 신고 가능합니다." 레이블
+    private let singleReportPerDayLabel: UILabel = {
+        let label = UILabel()
+        label.text = "하나의 리뷰에 대해 24시간 내 한 번만 신고 가능합니다."
+        label.font = EATSSUFontFamily.Pretendard.regular.font(size: 12)
+        label.textColor = EATSSUAsset.Color.GrayScale.gray600.color
+        return label
+    }()
+    
+    /// "메뉴와 관련없는 내용" 버튼
+    internal let unrelatedToMenuButton = ESReportButton(title: "메뉴와 관련없는 내용")
+    
+    /// "음란성, 욕설 등 부적절한 내용" 버튼
+    internal let inappropriateContentButton = ESReportButton(title: "음란성, 욕설 등 부적절한 내용")
+    
+    /// " 부적절한 홍보 또는 광고" 버튼
+    internal let inappropriatePromotionButton = ESReportButton(title: "부적절한 홍보 또는 광고")
+    
+    /// "리뷰 작성 취지에 맞지 않는 내용 (복사글 등)" 버튼
+    internal let offTopicContentButton = ESReportButton(title: "리뷰 작성 취지에 맞지 않는 내용 (복사글 등)")
+    
+    /// "저작권 도용 의심 (사진 등)" 버튼
+    internal let copyrightInfringementButton = ESReportButton(title: "저작권 도용 의심 (사진 등)")
+    
+    /// "기타 (하단 내용 작성)" 버튼
+    internal let otherReasonButton = ESReportButton(title: "기타 (하단 내용 작성)")
+    
+    /// "리뷰 신고 사유를 작성해 주세요" 텍스트필드
+    internal var reviewReportReasonTextView: UITextView = {
+        let textView = UITextView()
+        textView.font = EATSSUFontFamily.Pretendard.medium.font(size: 16)
+        textView.layer.cornerRadius = 10
+        textView.backgroundColor = EATSSUAsset.Color.GrayScale.gray100.color
+        textView.layer.borderWidth = 1
+        textView.layer.borderColor =  EATSSUAsset.Color.GrayScale.gray200.color.cgColor
+        textView.textContainerInset = UIEdgeInsets(top: 16.0, left: 16.0, bottom: 16.0, right: 16.0)
+        textView.isEditable = false
+        return textView
+    }()
+    
+    /// 0 / 300 와 같이 현재 작성된 글자 수 상태 레이블
+    internal var characterCountLabel: UILabel = {
+        let label = UILabel()
+        label.text = "0 / 300"
+        label.font = EATSSUFontFamily.Pretendard.regular.font(size: 12)
+        label.textColor = EATSSUAsset.Color.GrayScale.gray400.color
+        return label
+    }()
+    
+    /// "EAT SSU 팀에게 보내기" 버튼
+    internal let sendToEATSSUButton = ESButton(size: .big, title: "EAT SSU 팀에게 보내기")
+    
+    // MARK: - Functions
     
     override func configureUI() {
         self.addSubviews(
-          reviewReportReasonLabel,
-          singleReportPerDayLabel,
-          unrelatedToMenuButton,
-          inappropriateContentButton,
-          inappropriatePromotionButton,
-          offTopicContentButton,
-          copyrightInfringementButton,
-          otherReasonButton,
-          reviewReportReasonTextView,
-          characterCountLabel,
-          sendToEATSSUButton
+            reviewReportReasonLabel,
+            singleReportPerDayLabel,
+            unrelatedToMenuButton,
+            inappropriateContentButton,
+            inappropriatePromotionButton,
+            offTopicContentButton,
+            copyrightInfringementButton,
+            otherReasonButton,
+            reviewReportReasonTextView,
+            characterCountLabel,
+            sendToEATSSUButton
         )
     }
-  
-  internal override func setLayout() {
-    reviewReportReasonLabel.snp.makeConstraints { make in
-      make.leading.equalTo(self).inset(24)
-      make.top.equalTo(safeAreaLayoutGuide.snp.top)
+    
+    internal override func setLayout() {
+        reviewReportReasonLabel.snp.makeConstraints { make in
+            make.leading.equalTo(self).inset(24)
+            make.top.equalTo(safeAreaLayoutGuide.snp.top)
+        }
+        
+        singleReportPerDayLabel.snp.makeConstraints { make in
+            make.leading.equalTo(self).inset(24)
+            make.top.equalTo(reviewReportReasonLabel.snp.bottom).offset(4)
+        }
+        
+        unrelatedToMenuButton.snp.makeConstraints { make in
+            make.leading.trailing.equalTo(self).inset(24)
+            make.height.equalTo(52)
+            make.top.equalTo(singleReportPerDayLabel.snp.bottom).offset(16)
+        }
+        
+        inappropriateContentButton.snp.makeConstraints { make in
+            make.leading.trailing.equalTo(self).inset(24)
+            make.height.equalTo(52)
+            make.top.equalTo(unrelatedToMenuButton.snp.bottom).offset(12)
+        }
+        
+        inappropriatePromotionButton.snp.makeConstraints { make in
+            make.leading.trailing.equalTo(self).inset(24)
+            make.height.equalTo(52)
+            make.top.equalTo(inappropriateContentButton.snp.bottom).offset(12)
+        }
+        
+        offTopicContentButton.snp.makeConstraints { make in
+            make.leading.trailing.equalTo(self).inset(24)
+            make.height.equalTo(52)
+            make.top.equalTo(inappropriatePromotionButton.snp.bottom).offset(12)
+        }
+        
+        copyrightInfringementButton.snp.makeConstraints { make in
+            make.leading.trailing.equalTo(self).inset(24)
+            make.height.equalTo(52)
+            make.top.equalTo(offTopicContentButton.snp.bottom).offset(12)
+        }
+        
+        otherReasonButton.snp.makeConstraints { make in
+            make.leading.trailing.equalTo(self).inset(24)
+            make.height.equalTo(52)
+            make.top.equalTo(copyrightInfringementButton.snp.bottom).offset(12)
+        }
+        
+        reviewReportReasonTextView.snp.makeConstraints { make in
+            make.leading.trailing.equalTo(self).inset(24)
+            make.height.equalTo(180)
+            make.top.equalTo(otherReasonButton.snp.bottom).offset(16)
+        }
+        
+        characterCountLabel.snp.makeConstraints { make in
+            make.trailing.equalTo(reviewReportReasonTextView)
+            make.top.equalTo(reviewReportReasonTextView.snp.bottom).offset(6)
+        }
+        
+        sendToEATSSUButton.snp.makeConstraints { make in
+            make.leading.trailing.equalTo(self).inset(24)
+            make.height.equalTo(52)
+            make.top.equalTo(reviewReportReasonTextView.snp.bottom).offset(56)
+        }
     }
     
-    singleReportPerDayLabel.snp.makeConstraints { make in
-      make.leading.equalTo(self).inset(24)
-      make.top.equalTo(reviewReportReasonLabel.snp.bottom).offset(4)
-    }
-    
-    unrelatedToMenuButton.snp.makeConstraints { make in
-      make.leading.trailing.equalTo(self).inset(24)
-      make.height.equalTo(52)
-      make.top.equalTo(singleReportPerDayLabel.snp.bottom).offset(16)
-    }
-    
-    inappropriateContentButton.snp.makeConstraints { make in
-      make.leading.trailing.equalTo(self).inset(24)
-      make.height.equalTo(52)
-      make.top.equalTo(unrelatedToMenuButton.snp.bottom).offset(12)
-    }
-    
-    inappropriatePromotionButton.snp.makeConstraints { make in
-      make.leading.trailing.equalTo(self).inset(24)
-      make.height.equalTo(52)
-      make.top.equalTo(inappropriateContentButton.snp.bottom).offset(12)
-    }
-
-    offTopicContentButton.snp.makeConstraints { make in
-      make.leading.trailing.equalTo(self).inset(24)
-      make.height.equalTo(52)
-      make.top.equalTo(inappropriatePromotionButton.snp.bottom).offset(12)
-    }
-
-    copyrightInfringementButton.snp.makeConstraints { make in
-      make.leading.trailing.equalTo(self).inset(24)
-      make.height.equalTo(52)
-      make.top.equalTo(offTopicContentButton.snp.bottom).offset(12)
-    }
-
-    otherReasonButton.snp.makeConstraints { make in
-      make.leading.trailing.equalTo(self).inset(24)
-      make.height.equalTo(52)
-      make.top.equalTo(copyrightInfringementButton.snp.bottom).offset(12)
-    }
-    
-    reviewReportReasonTextView.snp.makeConstraints { make in
-      make.leading.trailing.equalTo(self).inset(24)
-      make.height.equalTo(180)
-      make.top.equalTo(otherReasonButton.snp.bottom).offset(16)
-    }
-    
-    characterCountLabel.snp.makeConstraints { make in
-      make.trailing.equalTo(reviewReportReasonTextView)
-      make.top.equalTo(reviewReportReasonTextView.snp.bottom).offset(6)
-    }
-    
-    sendToEATSSUButton.snp.makeConstraints { make in
-      make.leading.trailing.equalTo(self).inset(24)
-      make.height.equalTo(52)
-      make.top.equalTo(reviewReportReasonTextView.snp.bottom).offset(56)
-    }
-  }
-
 }

--- a/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Review/View/RerportView/ReportView.swift
+++ b/EATSSU_MVC/EATSSU_MVC/Sources/Presentation/Review/View/RerportView/ReportView.swift
@@ -16,9 +16,6 @@ import EATSSUComponents
 
 final class ReportView: BaseUIView {
   
-  // MARK: - Properties
-  
-  
   // MARK: - UI Components
   
   /// "리뷰 신고 사유를 알려주세요" 레이블


### PR DESCRIPTION
# 🍎 EATSSU iOS Team Pull Request

## 🔆 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 리뷰 신고 페이지에서 제목 문구가 완성되지 않는 문제 해결 및 좌측 정렬 속성 추가했습니다.

## 💡 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- EATSSUComponent의 `ESReportButton` 속성 수정했습니다.
- TODO 주석으로 남겨놓은 것처럼 아래 코드는 현재 Deprecated 되었기에 UIButtonConfiguration 속성 사용할 경우 해당사항 적용안됩니다.
현재 EATSSUComponent에서 Configuration 속성을 사용하지 않기 때문에 상관없긴하지만, `setProperties` 코드의 속성을 `Configuration` 을 적용할 필요가 있다고 생각합니다.
<img width="869" alt="image" src="https://github.com/user-attachments/assets/f00294d9-9458-4636-bba6-80fd701f61b7">

---
- (참고로 남겨둡니다)
보통 해당 코드 사용하여 좌측정렬 많이 하는데요. 적용이 안되더라구요? 
**`self.titleLabel?.textAlignment = .left`**  
titleLabel의 textAlignment 속성은 UILabel의 속성으로 버튼 내의 레이블 텍스트의 정렬 방식을 지정하는 속성이죠. 하지만 이는 전체적인 콘텐츠 정렬에는 영향을 미치지 않습니다. 따라서 버튼은 여전히 자체적인 콘텐츠 레이아웃 정렬 방식을 따르고 있어, 그에 따라 레이블의 정렬이 제한됩니다. 
**`self.contentHorizontalAlignment = .left`**
해당 코드는 내부적인 모든 콘텐츠(텍스트, 이미지)의 정렬 방식을 지정합니다. 

   저는 두번째 코드로 해결했습니다. 
## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
<img width="394" alt="스크린샷 2024-10-18 오후 6 42 39" src="https://github.com/user-attachments/assets/b5e0a625-48db-4df1-91b7-95a319a80496">

<img width="402" alt="스크린샷 2024-10-18 오후 6 30 43" src="https://github.com/user-attachments/assets/b1ed5c25-71f0-413b-bceb-e36c4072a08b">


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #38
