### PR TITLE
[#172] 리뷰 삭제 Alert 추가

### DIFF
--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
@@ -164,16 +164,21 @@ extension MyReviewViewController {
             }
         }
     }
-
+    
+    // 리뷰 삭제 알람 추가
     func deleteReview(reviewID: Int) {
-        reviewProvider.request(.deleteReview(reviewID)) { response in
-            switch response {
-            case .success:
-                self.getMyReview()
-                self.view.showToast(message: "삭제되었어요 !")
-            case let .failure(err):
-                print(err.localizedDescription)
+        let alert = UIAlertController(title: "리뷰 삭제", message: "리뷰를 삭제하시겠습니까?", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "삭제", style: .destructive) { _ in
+            self.reviewProvider.request(.deleteReview(reviewID)) { response in
+                switch response {
+                case .success:
+                    self.getMyReview()
+                case let .failure(err):
+                    print(err.localizedDescription)
+                }
             }
-        }
+        })
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        present(alert, animated: true)
     }
 }


### PR DESCRIPTION
- 내 리뷰에서 삭제 시 리뷰 삭제 Alert 띄우기

#172

# 🍎 EATSSU iOS Team Pull Request

## 🔆 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 내 리뷰에서 수정/삭제 더보기 중 삭제 선택 시 "리뷰 삭제하시겠습니까?" Alert 추가

## 💡 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- Alert에서 삭제 버튼 색상을 신고하기 처럼 파란색으로 해야할까요?

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
<img width="395" alt="스크린샷 2025-03-03 오후 7 43 48" src="https://github.com/user-attachments/assets/4528bb50-5634-44ab-a6db-2881f3b93853" />


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #172
