### PR TITLE
[#264] latestVersion > currentVersion인 경우에만 강제 업데이트 알럿 설정

### DIFF
--- a/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
@@ -82,12 +82,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             print("앱스토어 버전을 찾지 못했습니다.")
             return
         }
-
         let currentVersion = AppStoreCheck.appVersion ?? ""
-        if latestVersion != currentVersion {
+        
+        let compareResult = latestVersion.compare(currentVersion, options: .numeric)
+        switch compareResult {
+        case .orderedAscending, .orderedSame:
+            debugPrint("현재 최신 버전입니다.")
+        case .orderedDescending:
             showUpdateAlert()
-        } else {
-            print("현재 최신 버전입니다.")
         }
     }
 


### PR DESCRIPTION
# 🍎 EATSSU iOS Team Pull Request

## 🔆 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- latestVersion > currentVersion인 경우에만 강제 업데이트 알럿 설정

## 💡 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- as is
    - latestVersion != currentVersion 의 경우, 강제 업데이트 알럿 띄움. 
    - Lookup API 캐시 갱신이 느려, 업데이트를 진행했음에도 동기화 안됨.

- to be 
   - `latestVersion(앱스토어 버전) > currentVersion(사용자 앱버전)` 시 알럿 띄움.
   - 업데이트 진행 후, 동기화 안된 경우 latestVersion(2.2.2) < currentVersion(2.2.3) 이므로, 갱신 느려도 문제없음.
```
let compareResult = latestVersion.compare(currentVersion, options: .numeric)
switch compareResult {
case .orderedAscending, .orderedSame:
    /// latestVersion <= currentVersion
    debugPrint("현재 최신 버전입니다.")
case .orderedDescending:
    /// latestVersion > currentVersion
    showUpdateAlert()
}
```

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #264 
