### PR TITLE
[#266] Splash 뷰 기본 버전으로 변경

### DIFF
--- a/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
@@ -19,11 +19,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         // 스플래시
-        let splashVC = NoticeSplashViewController()
+        let splashVC = SplashViewController()
         window?.rootViewController = splashVC
         window?.makeKeyAndVisible()
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.5) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
             self?.fetchNoticeAndConfigureRootViewController()
             self?.checkForAppUpdate()
         }

--- a/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
@@ -23,10 +23,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = splashVC
         window?.makeKeyAndVisible()
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-            self?.fetchNoticeAndConfigureRootViewController()
-            self?.checkForAppUpdate()
-        }
+        fetchNoticeAndConfigureRootViewController()
+        checkForAppUpdate()
     }
 
     func scene(_: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {


### PR DESCRIPTION
# 🍎 EATSSU iOS Team Pull Request

## 🔆 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- splash 뷰를 기본 버전으로 변경했습니다.

## 💡 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 기존이 원래 1초 정도였어서 스플래시 유지 초를 3.5초에서 1.0초로 변경했습니다. 1초면 적당할까요?
- color 에셋의 primary로 배경색을 지정하니, 원래 있던 스플래시 화면보다 연해졌는데 바꾼 색상이 맞는 것 같아서 바꿨습니다.

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
- 변경 전
<img src="https://github.com/user-attachments/assets/7c65698e-f775-4dae-9e75-4f4666d04a58" width="200" height="450">

- 변경 후
<img src="https://github.com/user-attachments/assets/8e51adc4-9778-43f2-a65a-47289e755148" width="200" height="450">

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #266
