### PR TITLE
[#284]  OS 메모리에서 해제하지 않고 오랜만에 앱에 들어왔을 때 오늘 날짜로 갱신 및 업데이트 최적화

### DIFF
--- a/EATSSU/App/Sources/Presentation/Home/View/HomeCalendarView.swift
+++ b/EATSSU/App/Sources/Presentation/Home/View/HomeCalendarView.swift
@@ -51,6 +51,15 @@ final class HomeCalendarView: BaseUIView {
         calendar.dataSource = self
         calendar.delegate = self
     }
+    
+    
+    /// 특정 날짜로 선택하고 해당 월로 스크롤합니다.
+    func setSelected(date: Date) {
+        // 날짜를 선택
+        calendar.select(date)
+        // 달력을 해당 날짜가 포함된 페이지로 이동
+        calendar.setCurrentPage(date, animated: true)
+    }
 }
 
 extension HomeCalendarView: FSCalendarDataSource, FSCalendarDelegate {

--- a/EATSSU/App/Sources/Presentation/Home/ViewController/HomeViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Home/ViewController/HomeViewController.swift
@@ -36,6 +36,19 @@ final class HomeViewController: BaseViewController {
         setLayout()
         registerTabman()
         setupNavigationBar()
+        
+        // 이미 등록된 옵저버가 있으면 먼저 제거
+        NotificationCenter.default.removeObserver(self, name: .didEnterNewDay, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleNewDayNotification(_:)),
+            name: .didEnterNewDay,
+            object: nil
+        )
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: .didEnterNewDay, object: nil)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -136,6 +149,16 @@ final class HomeViewController: BaseViewController {
 
     private func setupDelegates() {
         homeCalendarView.delegate = tabmanController
+    }
+    
+    @objc private func handleNewDayNotification(_ notification: Notification) {
+        // 백그라운드에서 돌아와 새로운 날로 판단될 때, 오늘 날짜로 갱신
+        DispatchQueue.main.async {
+            let today = Date()
+            self.currentDate = today
+            // 달력뷰에 오늘 날짜가 선택되도록 호출
+            self.homeCalendarView.setSelected(date: today)
+        }
     }
 }
 

--- a/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
@@ -202,21 +202,23 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
         
-        // 이전에 저장된 마지막 활성화 날짜가 있는지 확인
-        if let lastActive = defaults.object(forKey: "lastActiveDate") as? Date {
-            // 저장된 날짜의 시점을 계산하여 비교 기준으로 사용
-            let lastDay = calendar.startOfDay(for: lastActive)
-            // 오늘이 마지막 활성화 날짜보다 이후인지 검사
-            if calendar.compare(today, to: lastDay, toGranularity: .day) == .orderedDescending {
-                // 새로운 날로 판단될 때, 알림을 보냄
-                NotificationCenter.default.post(name: .didEnterNewDay, object: nil)
-            }
-        } else {
-            // 저장된 날짜가 없으면 첫 실행이므로 초기 업데이트를 위해 알림을 보냅니다.
+        defer {
+            // 마지막 활성화 날짜를 현재 시점으로 업데이트하여 다음 비교에 사용
+            defaults.set(Date(), forKey: "lastActiveDate")
+        }
+
+        guard let lastActive = defaults.object(forKey: "lastActiveDate") as? Date else {
+            // 저장된 날짜가 없으면 첫 실행이므로 초기 업데이트를 위해 알림을 보냄
             NotificationCenter.default.post(name: .didEnterNewDay, object: nil)
+            return
         }
         
-        // 마지막 활성화 날짜를 현재 시점으로 업데이트하여 다음 비교에 사용
-        defaults.set(Date(), forKey: "lastActiveDate")
+        // 저장된 날짜의 시점을 계산하여 비교 기준으로 사용
+        let lastDay = calendar.startOfDay(for: lastActive)
+        // 오늘이 마지막 활성화 날짜보다 이후인지 검사
+        if calendar.compare(today, to: lastDay, toGranularity: .day) == .orderedDescending {
+            // 새로운 날로 판단될 때, 알림을 보냄
+            NotificationCenter.default.post(name: .didEnterNewDay, object: nil)
+        }
     }
 }

--- a/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
@@ -196,8 +196,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController?.present(alert, animated: true, completion: nil)
     }
     
-    /// 마지막 활성화 날짜와 비교해 “새로운 날”이면 알림을 보내고,
-    /// 마지막 활성화 시간을 갱신합니다.
+    /// 마지막 활성화 날짜와 비교해 “새로운 날”이면 알림을 보내고, 마지막 활성화 시간을 갱신
     private func checkAndNotifyNewDay() {
         let defaults = UserDefaults.standard
         let calendar = Calendar.current
@@ -209,7 +208,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let lastDay = calendar.startOfDay(for: lastActive)
             // 오늘이 마지막 활성화 날짜보다 이후인지 검사
             if calendar.compare(today, to: lastDay, toGranularity: .day) == .orderedDescending {
-                // 새로운 날로 판단될 때, 관련 로직이 실행되도록 알림을 보냅니다.
+                // 새로운 날로 판단될 때, 알림을 보냄
                 NotificationCenter.default.post(name: .didEnterNewDay, object: nil)
             }
         } else {
@@ -217,7 +216,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             NotificationCenter.default.post(name: .didEnterNewDay, object: nil)
         }
         
-        // 마지막 활성화 날짜를 현재 시점으로 업데이트하여 다음 비교에 사용합니다.
+        // 마지막 활성화 날짜를 현재 시점으로 업데이트하여 다음 비교에 사용
         defaults.set(Date(), forKey: "lastActiveDate")
     }
 }

--- a/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
@@ -48,6 +48,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func sceneWillEnterForeground(_ scene: UIScene) {
         // 백그라운드에서 포그라운드로 전환 시 필요한 작업 수행
+        checkAndNotifyNewDay()
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
@@ -193,5 +194,30 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         alert.addAction(updateAction)
         window?.rootViewController?.present(alert, animated: true, completion: nil)
+    }
+    
+    /// 마지막 활성화 날짜와 비교해 “새로운 날”이면 알림을 보내고,
+    /// 마지막 활성화 시간을 갱신합니다.
+    private func checkAndNotifyNewDay() {
+        let defaults = UserDefaults.standard
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        
+        // 이전에 저장된 마지막 활성화 날짜가 있는지 확인
+        if let lastActive = defaults.object(forKey: "lastActiveDate") as? Date {
+            // 저장된 날짜의 시점을 계산하여 비교 기준으로 사용
+            let lastDay = calendar.startOfDay(for: lastActive)
+            // 오늘이 마지막 활성화 날짜보다 이후인지 검사
+            if calendar.compare(today, to: lastDay, toGranularity: .day) == .orderedDescending {
+                // 새로운 날로 판단될 때, 관련 로직이 실행되도록 알림을 보냅니다.
+                NotificationCenter.default.post(name: .didEnterNewDay, object: nil)
+            }
+        } else {
+            // 저장된 날짜가 없으면 첫 실행이므로 초기 업데이트를 위해 알림을 보냅니다.
+            NotificationCenter.default.post(name: .didEnterNewDay, object: nil)
+        }
+        
+        // 마지막 활성화 날짜를 현재 시점으로 업데이트하여 다음 비교에 사용합니다.
+        defaults.set(Date(), forKey: "lastActiveDate")
     }
 }

--- a/EATSSU/App/Sources/Utility/Extension/Notification+.swift
+++ b/EATSSU/App/Sources/Utility/Extension/Notification+.swift
@@ -1,0 +1,13 @@
+//
+//  Notification.swift
+//  EATSSU
+//
+//  Created by 한금준 on 6/23/25.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let didEnterNewDay = Notification.Name("didEnterNewDay")
+    // 추가 알림 이름도 여기 모아서 관리
+}


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #이슈번호

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 백그라운드에서 포그라운드로 전환 시, 마지막 활성화 날짜와 비교해 “새로운 날”이면 HomeViewController에 알림을 보내고, 마지막 활성화 시간을 갱신해서 앱을 메모리에서 해제하지 않고 다음날 혹은 며칠 이후 앱에 다시 접속할 때, 오늘 날짜로 갱신하도록 수정

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
