### PR TITLE
[#293] 토큰 재발급 로직 리팩토링

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,10 @@
+have_fun: true
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+ignore_patterns: []

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,4 @@
+- All review comments and explanations must be written in Korean, regardless of the input language.
+- Reviews must be specific and clear.
+- Feedback should be based on logical reasoning.
+- Keep comments to a single line whenever possible.

--- a/EATSSU/App/Sources/Data/Network/Foundation/AuthInterceptor.swift
+++ b/EATSSU/App/Sources/Data/Network/Foundation/AuthInterceptor.swift
@@ -57,16 +57,13 @@ final class AuthInterceptor: RequestInterceptor {
         print("retry 호출 – statusCode: \(statusCode)")
         
         // Swift Concurrency 기반 비동기 재발급 처리
-        _Concurrency.Task { @MainActor in
+        _Concurrency.Task { 
             do {
-                try await TokenRefresher.shared.refreshIfNeeded()
-                completion(.retry)
+              try await TokenRefresher.shared.refreshIfNeeded()
+              await MainActor.run { completion(.retry) }
             } catch {
-                print("재발급 실패 – error: \(error)")
-                
-                // 세션 만료 등으로 재발급 실패 시 실패 처리
-                completion(.doNotRetryWithError(error))
+              await MainActor.run { completion(.doNotRetryWithError(error)) }
             }
-        }
+          }
     }
 }

--- a/EATSSU/App/Sources/Data/Network/Foundation/AuthInterceptor.swift
+++ b/EATSSU/App/Sources/Data/Network/Foundation/AuthInterceptor.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+
 import Alamofire
 import Moya
 

--- a/EATSSU/App/Sources/Data/Network/Foundation/AuthInterceptor.swift
+++ b/EATSSU/App/Sources/Data/Network/Foundation/AuthInterceptor.swift
@@ -4,68 +4,66 @@
 //
 //  Created by 최지우 on 11/13/23.
 //
-import Foundation
 
+import Foundation
 import Alamofire
 import Moya
 
+/// 네트워크 요청에 accessToken을 자동 부착하고,
+/// 인증 실패 시 refreshToken으로 자동 재발급을 시도하는 인터셉터
 final class AuthInterceptor: RequestInterceptor {
     
     static let shared = AuthInterceptor()
-    private let reissueProvider = MoyaProvider<ReissueRouter>()
     
-    func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
-        var urlRequest = urlRequest
+    /// accessToken이 만료되었을 때 재시도할 상태코드 목록
+    private let refreshStatusCodes: Set<Int> = [401, 403]
+    
+    /// 모든 요청에 accessToken을 부착 (단, 재발급 요청은 예외)
+    func adapt(_ urlRequest: URLRequest,
+               for session: Session,
+               completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        var request = urlRequest
         
-        if urlRequest.url?.path == ReissueRouter.reissuance.path {
-            return completion(.success(urlRequest))
+        // 토큰 재발급 요청 자체에는 토큰을 붙이지 않음
+        if request.url?.path == ReissueRouter.reissuance.path {
+            return completion(.success(request))
         }
         
-        if let urlString = urlRequest.url?.absoluteString,
-            urlRequest.requiresToken {
-             urlRequest.headers.add(
-                 name: "Authorization",
-                 value: "Bearer \(RealmService.shared.getToken())"
-             )
-         }
-         completion(.success(urlRequest))
-     }
+        // 토큰이 필요한 요청에만 Authorization 헤더 추가
+        if request.requiresToken {
+            request.headers.add(
+                name: "Authorization",
+                value: "Bearer \(RealmService.shared.getToken())"
+            )
+        }
+        
+        completion(.success(request))
+    }
     
+    /// 인증 실패(401, 403) 발생 시 refreshToken으로 accessToken 재발급 시도
+    /// 성공하면 동일 요청을 재시도, 실패하면 그대로 실패 처리
     func retry(_ request: Request,
                for session: Session,
-               dueTo error: any Error,
+               dueTo error: Error,
                completion: @escaping (RetryResult) -> Void) {
         
-        if let response = request.task?.response as? HTTPURLResponse {
-            print("retry 호출 – statusCode:", response.statusCode)
-        } else {
-            print("retry 호출 – response 없음, error:", error)
+        // 응답 코드가 401 또는 403인 경우만 재발급 시도
+        guard let statusCode = (request.task?.response as? HTTPURLResponse)?.statusCode,
+              refreshStatusCodes.contains(statusCode) else {
+            return completion(.doNotRetryWithError(error))
         }
         
-        guard let response = request.task?.response as? HTTPURLResponse,
-              (response.statusCode == 401 || response.statusCode == 403) else {
-            completion(.doNotRetryWithError(error))
-            return
-        }
+        print("retry 호출 – statusCode: \(statusCode)")
         
-        reissueProvider.request(.reissuance) { [weak self] response in
-            switch response {
-            case let .success(moyaResponse):
-                do {
-                    let responseData = try moyaResponse.map(BaseResponse<SignResponse>.self)
-                    guard let data = responseData.result else {
-                        return
-                    }
-                    RealmService.shared.addToken(accessToken: data.accessToken,
-                                                 refreshToken: data.refreshToken)
-                    print("재발급 완료 – 새 accessToken:", data.accessToken)
-                    completion(.retry)
-                } catch let error {
-                    print("reissuance 실패 – error:", error)
-                    completion(.doNotRetryWithError(error))
-                }
+        // Swift Concurrency 기반 비동기 재발급 처리
+        _Concurrency.Task { @MainActor in
+            do {
+                try await TokenRefresher.shared.refreshIfNeeded()
+                completion(.retry)
+            } catch {
+                print("재발급 실패 – error: \(error)")
                 
-            case .failure(let error):
+                // 세션 만료 등으로 재발급 실패 시 실패 처리
                 completion(.doNotRetryWithError(error))
             }
         }

--- a/EATSSU/App/Sources/Data/Network/Foundation/AuthInterceptor.swift
+++ b/EATSSU/App/Sources/Data/Network/Foundation/AuthInterceptor.swift
@@ -17,25 +17,46 @@ final class AuthInterceptor: RequestInterceptor {
     func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
         var urlRequest = urlRequest
         
-        if let urlString = urlRequest.url?.absoluteString, urlRequest.requiresToken {
-            urlRequest.headers.add(name: "Authorization",
-                                   value: "Bearer \(RealmService.shared.getToken())")
+        if urlRequest.url?.path == ReissueRouter.reissuance.path {
+            return completion(.success(urlRequest))
         }
-        completion(.success(urlRequest))
-    }
+        
+        if let urlString = urlRequest.url?.absoluteString,
+            urlRequest.requiresToken {
+             urlRequest.headers.add(
+                 name: "Authorization",
+                 value: "Bearer \(RealmService.shared.getToken())"
+             )
+         }
+         completion(.success(urlRequest))
+     }
     
     func retry(_ request: Request,
                for session: Session,
                dueTo error: any Error,
                completion: @escaping (RetryResult) -> Void) {
-        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401 else {
+        
+        if let response = request.task?.response as? HTTPURLResponse {
+            print("🔁 retry 호출 – statusCode:", response.statusCode)
+        } else {
+            print("🔁 retry 호출 – response 없음, error:", error)
+        }
+        
+        guard let response = request.task?.response as? HTTPURLResponse,
+              (response.statusCode == 401 || response.statusCode == 403) else {
+            print("🚫 재발급 미진입 – statusCode가 401/403이 아님")
             completion(.doNotRetryWithError(error))
             return
         }
+
+        print("✅ 재발급 진입 – statusCode:", response.statusCode)
         
         reissueProvider.request(.reissuance) { [weak self] response in
+            print("🔄 reissuance API 호출 시작")
             switch response {
             case let .success(moyaResponse):
+                print("🔄 reissuance 성공 – rawData:", String(data: moyaResponse.data, encoding: .utf8) ?? "")
+
                 do {
                     let responseData = try moyaResponse.map(BaseResponse<SignResponse>.self)
                     guard let data = responseData.result else {
@@ -43,8 +64,10 @@ final class AuthInterceptor: RequestInterceptor {
                     }
                     RealmService.shared.addToken(accessToken: data.accessToken,
                                                  refreshToken: data.refreshToken)
+                    print("🔄 재발급 완료 – 새 accessToken:", data.accessToken)
                     completion(.retry)
                 } catch let error {
+                    print("❌ reissuance 실패 – error:", error)
                     completion(.doNotRetryWithError(error))
                 }
                 

--- a/EATSSU/App/Sources/Data/Network/Foundation/AuthInterceptor.swift
+++ b/EATSSU/App/Sources/Data/Network/Foundation/AuthInterceptor.swift
@@ -37,26 +37,20 @@ final class AuthInterceptor: RequestInterceptor {
                completion: @escaping (RetryResult) -> Void) {
         
         if let response = request.task?.response as? HTTPURLResponse {
-            print("🔁 retry 호출 – statusCode:", response.statusCode)
+            print("retry 호출 – statusCode:", response.statusCode)
         } else {
-            print("🔁 retry 호출 – response 없음, error:", error)
+            print("retry 호출 – response 없음, error:", error)
         }
         
         guard let response = request.task?.response as? HTTPURLResponse,
               (response.statusCode == 401 || response.statusCode == 403) else {
-            print("🚫 재발급 미진입 – statusCode가 401/403이 아님")
             completion(.doNotRetryWithError(error))
             return
         }
-
-        print("✅ 재발급 진입 – statusCode:", response.statusCode)
         
         reissueProvider.request(.reissuance) { [weak self] response in
-            print("🔄 reissuance API 호출 시작")
             switch response {
             case let .success(moyaResponse):
-                print("🔄 reissuance 성공 – rawData:", String(data: moyaResponse.data, encoding: .utf8) ?? "")
-
                 do {
                     let responseData = try moyaResponse.map(BaseResponse<SignResponse>.self)
                     guard let data = responseData.result else {
@@ -64,10 +58,10 @@ final class AuthInterceptor: RequestInterceptor {
                     }
                     RealmService.shared.addToken(accessToken: data.accessToken,
                                                  refreshToken: data.refreshToken)
-                    print("🔄 재발급 완료 – 새 accessToken:", data.accessToken)
+                    print("재발급 완료 – 새 accessToken:", data.accessToken)
                     completion(.retry)
                 } catch let error {
-                    print("❌ reissuance 실패 – error:", error)
+                    print("reissuance 실패 – error:", error)
                     completion(.doNotRetryWithError(error))
                 }
                 

--- a/EATSSU/App/Sources/Data/Network/Foundation/Logger.swift
+++ b/EATSSU/App/Sources/Data/Network/Foundation/Logger.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+
 import Moya
 
 /// 네트워크 로그 출력을 제어하는 플래그

--- a/EATSSU/App/Sources/Data/Network/Foundation/Logger.swift
+++ b/EATSSU/App/Sources/Data/Network/Foundation/Logger.swift
@@ -8,56 +8,28 @@
 import Foundation
 import Moya
 
-/// 네트워크 로깅을 위한 프로토콜입니다.
-///
-/// 이 프로토콜을 구현하여 네트워크 요청, 응답 및 오류를 기록할 수 있습니다.
+/// 네트워크 로그 출력을 제어하는 플래그
+private let isVerboseNetworkLoggingEnabled = false
+
+/// 네트워크 로깅을 위한 프로토콜
 protocol Logger {
-    /// 일반 메시지를 로깅합니다.
-    ///
-    /// - Parameter message: 로깅할 문자열 메시지
     func log(_ message: String)
-
-    /// 네트워크 요청 정보를 로깅합니다.
-    ///
-    /// - Parameters:
-    ///   - request: 전송된 `URLRequest` 객체
-    ///   - target: 해당 요청의 `TargetType`
     func logRequest(_ request: URLRequest, target: TargetType)
-
-    /// 네트워크 응답 정보를 로깅합니다.
-    ///
-    /// - Parameters:
-    ///   - response: 수신된 `Response` 객체
-    ///   - target: 해당 요청의 `TargetType`
     func logResponse(_ response: Response, target: TargetType)
-
-    /// 네트워크 오류 정보를 로깅합니다.
-    ///
-    /// - Parameters:
-    ///   - error: 발생한 `MoyaError` 객체
-    ///   - target: 해당 요청의 `TargetType`
     func logNetworkError(_ error: MoyaError, target: TargetType)
 }
 
-/// 기본 네트워크 로깅을 수행하는 구조체입니다.
-///
-/// `Logger` 프로토콜을 구현하며, 디버그 환경에서 콘솔 출력을 통해 로그를 기록합니다.
+/// 기본 네트워크 로거
 struct DefaultLogger: Logger {
-    /// 일반 메시지를 로깅합니다.
-    ///
-    /// - Parameter message: 로깅할 문자열 메시지
     func log(_ message: String) {
         #if DEBUG
-            print("📝 [로그]: \(message)")
+        print("📝 [로그]: \(message)")
         #endif
     }
 
-    /// 네트워크 요청 정보를 로깅합니다.
-    ///
-    /// - Parameters:
-    ///   - request: 전송된 `URLRequest` 객체
-    ///   - target: 해당 요청의 `TargetType`
     func logRequest(_ request: URLRequest, target: TargetType) {
+        guard isVerboseNetworkLoggingEnabled else { return }
+
         var log = """
         ⎡-------------------- 📤 서버 요청 시작 --------------------⎤
         요청 메서드: [\(request.httpMethod ?? "알 수 없음")]
@@ -68,24 +40,22 @@ struct DefaultLogger: Logger {
         if let headers = request.allHTTPHeaderFields, !headers.isEmpty {
             log += "\n요청 헤더:\n\(headers)"
         }
+
         if let body = request.httpBody,
-           let bodyString = String(data: body, encoding: .utf8)
-        {
+           let bodyString = String(data: body, encoding: .utf8) {
             log += "\n요청 바디:\n\(bodyString)"
         }
+
         log += "\n⎣-------------------- 📤 요청 종료 --------------------⎦"
 
         #if DEBUG
-            print(log)
+        print(log)
         #endif
     }
 
-    /// 네트워크 응답 정보를 로깅합니다.
-    ///
-    /// - Parameters:
-    ///   - response: 수신된 `Response` 객체
-    ///   - target: 해당 요청의 `TargetType`
     func logResponse(_ response: Response, target: TargetType) {
+        guard isVerboseNetworkLoggingEnabled else { return }
+
         var log = """
         ⎡-------------------- 📥 서버 응답 수신 --------------------⎤
         API 타겟: \(target)
@@ -96,19 +66,17 @@ struct DefaultLogger: Logger {
         if let responseData = String(data: response.data, encoding: .utf8) {
             log += "\n응답 데이터:\n\(responseData)"
         }
+
         log += "\n⎣-------------------- 📥 응답 종료 (\(response.data.count) 바이트) --------------------⎦"
 
         #if DEBUG
-            print(log)
+        print(log)
         #endif
     }
 
-    /// 네트워크 오류 정보를 로깅합니다.
-    ///
-    /// - Parameters:
-    ///   - error: 발생한 `MoyaError` 객체
-    ///   - target: 해당 요청의 `TargetType`
     func logNetworkError(_ error: MoyaError, target: TargetType) {
+        guard isVerboseNetworkLoggingEnabled else { return }
+
         let log = """
         🚨 네트워크 오류 발생 🚨
         오류 코드: \(error.errorCode)
@@ -118,7 +86,7 @@ struct DefaultLogger: Logger {
         """
 
         #if DEBUG
-            print(log)
+        print(log)
         #endif
     }
 }

--- a/EATSSU/App/Sources/Data/Network/Foundation/TokenManager.swift
+++ b/EATSSU/App/Sources/Data/Network/Foundation/TokenManager.swift
@@ -1,0 +1,66 @@
+//
+//  TokenManager.swift
+//  EATSSU
+//
+//  Created by 황상환 on 7/25/25.
+//
+
+import Foundation
+
+struct TokenPayload: Decodable {
+    let exp: TimeInterval
+}
+
+final class TokenManager {
+    static let shared = TokenManager()
+    private init() {}
+
+    /// 토큰 남은 시간이 [2시간] 이하이면 재발급 시도
+    private let expireThreshold: TimeInterval = 60 * 60 * 2
+    
+    /// accessToken 디코딩하여 만료 여부 판단
+    func isTokenExpiringSoon() -> Bool {
+        let token = RealmService.shared.getToken()
+        guard let payload = decodePayload(token: token) else {
+            return true // 디코딩 실패 시 만료로 간주
+        }
+
+        let expirationDate = Date(timeIntervalSince1970: payload.exp)
+        return Date() >= expirationDate.addingTimeInterval(-expireThreshold)
+    }
+
+    /// 재발급이 필요하면 TokenRefresher로 실행
+    func refreshIfNeeded() async {
+        if isTokenExpiringSoon() {
+            do {
+                try await TokenRefresher.shared.refreshIfNeeded()
+            } catch {
+                print("앱 시작/포그라운드 시 재발급 실패: \(error)")
+            }
+        }
+    }
+
+    /// JWT Payload 디코딩
+    private func decodePayload(token: String) -> TokenPayload? {
+        let parts = token.split(separator: ".")
+        guard parts.count == 3 else { return nil }
+
+        var base64 = parts[1]
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while base64.count % 4 != 0 {
+            base64 += "="
+        }
+
+        guard let data = Data(base64Encoded: base64) else { return nil }
+        return try? JSONDecoder().decode(TokenPayload.self, from: data)
+    }
+}
+
+extension TokenManager {
+    static func refreshIfNeededAsync() {
+        Task {
+            await TokenManager.shared.refreshIfNeeded()
+        }
+    }
+}

--- a/EATSSU/App/Sources/Data/Network/Foundation/TokenRefresher.swift
+++ b/EATSSU/App/Sources/Data/Network/Foundation/TokenRefresher.swift
@@ -1,0 +1,60 @@
+//
+//  TokenRefresher.swift
+//  EATSSU
+//
+//  Created by 황상환 on 7/24/25.
+//
+
+import Moya
+
+actor TokenRefresher {
+    static let shared = TokenRefresher()
+
+    private var isRefreshing = false
+    private var waitingContinuations: [CheckedContinuation<Void, Error>] = []
+
+    func refreshIfNeeded() async throws {
+        if isRefreshing {
+            return try await withCheckedThrowingContinuation { continuation in
+                waitingContinuations.append(continuation)
+            }
+        }
+
+        isRefreshing = true
+        defer {
+            isRefreshing = false
+        }
+
+        do {
+            let data = try await performReissuance()
+            RealmService.shared.addToken(accessToken: data.accessToken,
+                                         refreshToken: data.refreshToken)
+
+            waitingContinuations.forEach { $0.resume() }
+            waitingContinuations.removeAll()
+        } catch {
+            waitingContinuations.forEach { $0.resume(throwing: error) }
+            waitingContinuations.removeAll()
+            throw error
+        }
+    }
+
+    private func performReissuance() async throws -> SignResponse {
+        try await withCheckedThrowingContinuation { continuation in
+            let provider = MoyaProvider<ReissueRouter>()
+            provider.request(.reissuance) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let result = try response.map(BaseResponse<SignResponse>.self).result!
+                        continuation.resume(returning: result)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/EATSSU/App/Sources/Data/Network/Foundation/TokenRefresher.swift
+++ b/EATSSU/App/Sources/Data/Network/Foundation/TokenRefresher.swift
@@ -39,8 +39,9 @@ actor TokenRefresher {
                 accessToken: data.accessToken,
                 refreshToken: data.refreshToken
             )
+#if DEBUG
             print("⭐️⭐️ 재발급 완료 ⭐️⭐️ – 새 accessToken:", data.accessToken)
-
+#endif
             // 대기 중인 모든 요청에 성공 전파
             waitingContinuations.forEach { $0.resume() }
             waitingContinuations.removeAll()

--- a/EATSSU/App/Sources/Data/Network/Foundation/TokenRefresher.swift
+++ b/EATSSU/App/Sources/Data/Network/Foundation/TokenRefresher.swift
@@ -7,12 +7,19 @@
 
 import Moya
 
+enum TokenRefresherError: Error {
+    case emptyResult
+    case sessionExpired
+}
+
 actor TokenRefresher {
     static let shared = TokenRefresher()
 
     private var isRefreshing = false
     private var waitingContinuations: [CheckedContinuation<Void, Error>] = []
 
+    /// accessToken이 만료되었을 경우 refreshToken으로 재발급 시도
+    /// 동시에 여러 요청이 실패해도 중복 재발급 요청은 막고, 기다리게 함
     func refreshIfNeeded() async throws {
         if isRefreshing {
             return try await withCheckedThrowingContinuation { continuation in
@@ -27,30 +34,47 @@ actor TokenRefresher {
 
         do {
             let data = try await performReissuance()
-            RealmService.shared.addToken(accessToken: data.accessToken,
-                                         refreshToken: data.refreshToken)
+            RealmService.shared.addToken(
+                accessToken: data.accessToken,
+                refreshToken: data.refreshToken
+            )
+            print("⭐️⭐️ 재발급 완료 ⭐️⭐️ – 새 accessToken:", data.accessToken)
 
+            // 대기 중인 모든 요청에 성공 전파
             waitingContinuations.forEach { $0.resume() }
             waitingContinuations.removeAll()
         } catch {
+            // 대기 중인 모든 요청에 실패 전파
             waitingContinuations.forEach { $0.resume(throwing: error) }
             waitingContinuations.removeAll()
             throw error
         }
     }
 
+    /// refreshToken 기반으로 accessToken 재발급 요청
     private func performReissuance() async throws -> SignResponse {
         try await withCheckedThrowingContinuation { continuation in
             let provider = MoyaProvider<ReissueRouter>()
             provider.request(.reissuance) { result in
                 switch result {
                 case .success(let response):
+                    // 서버가 refreshToken도 만료된 경우
+                    if response.statusCode == 403 {
+                        continuation.resume(throwing: TokenRefresherError.sessionExpired)
+                        return
+                    }
+
                     do {
-                        let result = try response.map(BaseResponse<SignResponse>.self).result!
+                        let base = try response.map(BaseResponse<SignResponse>.self)
+                        guard let result = base.result else {
+                            continuation.resume(throwing: TokenRefresherError.emptyResult)
+                            return
+                        }
                         continuation.resume(returning: result)
                     } catch {
                         continuation.resume(throwing: error)
                     }
+
                 case .failure(let error):
                     continuation.resume(throwing: error)
                 }

--- a/EATSSU/App/Sources/Data/Network/Foundation/TokenRefresher.swift
+++ b/EATSSU/App/Sources/Data/Network/Foundation/TokenRefresher.swift
@@ -17,6 +17,7 @@ actor TokenRefresher {
 
     private var isRefreshing = false
     private var waitingContinuations: [CheckedContinuation<Void, Error>] = []
+    private let provider = MoyaProvider<ReissueRouter>()
 
     /// accessToken이 만료되었을 경우 refreshToken으로 재발급 시도
     /// 동시에 여러 요청이 실패해도 중복 재발급 요청은 막고, 기다리게 함
@@ -54,7 +55,6 @@ actor TokenRefresher {
     /// refreshToken 기반으로 accessToken 재발급 요청
     private func performReissuance() async throws -> SignResponse {
         try await withCheckedThrowingContinuation { continuation in
-            let provider = MoyaProvider<ReissueRouter>()
             provider.request(.reissuance) { result in
                 switch result {
                 case .success(let response):

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/SetNickNameViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/SetNickNameViewController.swift
@@ -108,7 +108,7 @@ final class SetNickNameViewController: BaseViewController {
     
     private func navigateToLogin() {
         let loginVC = LoginViewController()
-        loginVC.toastMessage = "시스템 오류로 다시 로그인해주세요"
+        loginVC.toastMessage = "세션이 만료되었습니다. 다시 로그인해주세요."
         DispatchQueue.main.async {
             if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) {

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
@@ -123,7 +123,7 @@ final class MyReviewViewController: BaseViewController {
     
     private func navigateToLogin() {
         let loginVC = LoginViewController()
-        loginVC.toastMessage = "시스템 오류로 다시 로그인해주세요"
+        loginVC.toastMessage = "세션이 만료되었습니다. 다시 로그인해주세요."
         DispatchQueue.main.async {
             if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) {

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
@@ -523,7 +523,7 @@ extension SetRateViewController {
     
     private func navigateToLogin() {
         let loginVC = LoginViewController()
-        loginVC.toastMessage = "시스템 오류로 다시 로그인해주세요"
+        loginVC.toastMessage = "세션이 만료되었습니다. 다시 로그인해주세요."
         DispatchQueue.main.async {
             if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) {

--- a/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
@@ -22,6 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         handleAppleSignIn()
         initializeKakaoSDK()
         setupDebugConfigurations()
+        TokenManager.refreshIfNeededAsync()
         UNUserNotificationCenter.current().delegate = self
 
         return true

--- a/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
@@ -48,6 +48,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func sceneWillEnterForeground(_ scene: UIScene) {
         // 백그라운드에서 포그라운드로 전환 시 필요한 작업 수행
+        TokenManager.refreshIfNeededAsync()
         checkAndNotifyNewDay()
     }
 

--- a/EATSSU/Project.swift
+++ b/EATSSU/Project.swift
@@ -52,6 +52,7 @@ let projectSettings: Settings = .settings(
         "OTHER_LDFLAGS": ["-all_load -Objc"],
         "DEVELOPMENT_LANGUAGE": "ko",
         "DEVELOPMENT_TEAM": "HZ8WU7PA4J",
+        "SWIFT_CONCURRENCY": "complete",
     ],
     configurations: [
         .debug(name: "Debug", xcconfig: "App/Resources/Secrets/Debug.xcconfig"),


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #293 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 토큰 재발급 시 **403 응답에 대한 예외 처리가 누락**되어 발생하던 문제를 수정했습니다.
- AuthInterceptor 내 reissueProvider를 제거하고, TokenRefresher 내부의 MoyaProvider(provider)를 이용해 Swift Concurrency 기반으로 재발급 로직을 구현했습니다.
- AuthInterceptor는 모든 네트워크 요청에 access token을 자동으로 포함시키고, 401/403 응답 시 TokenRefresher를 호출해 토큰을 재발급합니다.
- TokenRefresher는 저장된 refresh token을 기반으로 /auth/reissue API를 호출하여 새로운 access token을 받아 저장하고, 실패 시 에러를 throw 하도록 했습니다.
- TokenManager는 access token의 payload에서 exp 값을 추출하여 만료 여부를 판단하고, 남은 유효 시간이 2시간 이하면 재발급이 동작하게 설정했습니다. 이 로직은 **앱 실행 시와 포그라운드 전환 시 자동으로 수행**됩니다.
- LoginViewController.toastMessage는 "시스템 오류"에서 **"세션이 만료되었습니다"로 메시지를 수정**했습니다.
- 재발급 성공 시 발급과 동일하게 "⭐️⭐️ 재발급 완료 ⭐️⭐️" 로그를 출력해 가독성을 높였습니다.
- Logger 파일 내 주석을 정리하고, 개발 중에 로그를 쉽게 제어할 수 있도록 제어 변수를 추가했습니다. 현재는 false로 설정되어 있습니다.
- 제미나이 세팅을 추가했습니다.

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

현재 로직은 토큰 관련 로직 다음과 같습니다.
- access token 만료 → refresh token으로 재발급 시도
- refresh token까지 만료된 경우 → 인증이 필요한 요청 시에만 "세션 만료" 메시지와 함께 로그인 창으로 이동
하지만 방학에는 장기간 앱을 사용하지 않을 사용자도 있을텐데 그렇게 되면 refresh token도 만료될 수 있습니다.
이 경우, 홈 화면은 인증 없이 접근 가능하기 때문에 앱 실행 직후 로그인 창으로 전환되지 않고 정상 진입합니다.

> Q. refresh token이 만료된 경우 앱 실행 직후 로그인 화면으로 강제 전환하는 게 나을까요? 아니면 현재처럼 인증 요청 시점에만 로그인 창으로 이동하는 게 자연스러울까요?

팀원 분들의 의견이 궁금합니다. 
작업 내용 중에도 수정사항이 있다면 말씀해주세요!