### PR TITLE
[#298] 탈퇴 후 로그인 페이지으로 푸시시, 토스트 메시지 추가

### DIFF
--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/UserWithdrawViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/UserWithdrawViewController.swift
@@ -136,7 +136,7 @@ extension UserWithdrawViewController {
                        let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow })
                     {
                         keyWindow.replaceRootViewController(UINavigationController(rootViewController: loginViewController))
-                        loginViewController.view.showToast(message: "탈퇴 처리가 완료되었습니다.")
+                        loginViewController.toastMessage = "탈퇴 처리가 완료되었습니다."
                     }
                 } catch let err {
                     print(err.localizedDescription)

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/UserWithdrawViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/UserWithdrawViewController.swift
@@ -136,6 +136,7 @@ extension UserWithdrawViewController {
                        let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow })
                     {
                         keyWindow.replaceRootViewController(UINavigationController(rootViewController: loginViewController))
+                        loginViewController.view.showToast(message: "탈퇴 처리가 완료되었습니다.")
                     }
                 } catch let err {
                     print(err.localizedDescription)

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/UserWithdrawViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/UserWithdrawViewController.swift
@@ -135,8 +135,8 @@ extension UserWithdrawViewController {
                     if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                        let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow })
                     {
-                        keyWindow.replaceRootViewController(UINavigationController(rootViewController: loginViewController))
                         loginViewController.toastMessage = "탈퇴 처리가 완료되었습니다."
+                        keyWindow.replaceRootViewController(UINavigationController(rootViewController: loginViewController))
                     }
                 } catch let err {
                     print(err.localizedDescription)


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #298 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 탈퇴 이후 별도 액션 없이 화면이 바뀌며 튕기는 듯한 경험을 주어, 이를 개선하기 위한 토스트 메시지 추가합니다.
- 이번 회의에서 안드와 통일해야 할 사항 있는지 확인 후, 추가 작업하겠습니다.

https://github.com/user-attachments/assets/ae90b737-5fce-4000-9074-9b8c47405b48


### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
