### PR TITLE
[#302] AuthService 도입 및 SceneDelegate 책임 분리 코드 리팩토링 

### DIFF
--- a/EATSSU/App/Sources/Data/Network/Foundation/AuthInterceptor.swift
+++ b/EATSSU/App/Sources/Data/Network/Foundation/AuthInterceptor.swift
@@ -59,12 +59,11 @@ final class AuthInterceptor: RequestInterceptor {
         // Swift Concurrency 기반 비동기 재발급 처리
         _Concurrency.Task { 
             do {
-                try await AuthService.shared.checkToken()
-                   await MainActor.run { completion(.retry) }
-               } catch {
-                   AuthService.shared.logout()
-                   await MainActor.run { completion(.doNotRetry) }
-               }
+              try await TokenRefresher.shared.refreshIfNeeded()
+              await MainActor.run { completion(.retry) }
+            } catch {
+              await MainActor.run { completion(.doNotRetryWithError(error)) }
+            }
           }
     }
 }

--- a/EATSSU/App/Sources/Data/Network/Foundation/AuthInterceptor.swift
+++ b/EATSSU/App/Sources/Data/Network/Foundation/AuthInterceptor.swift
@@ -59,11 +59,12 @@ final class AuthInterceptor: RequestInterceptor {
         // Swift Concurrency 기반 비동기 재발급 처리
         _Concurrency.Task { 
             do {
-              try await TokenRefresher.shared.refreshIfNeeded()
-              await MainActor.run { completion(.retry) }
-            } catch {
-              await MainActor.run { completion(.doNotRetryWithError(error)) }
-            }
+                try await AuthService.shared.checkToken()
+                   await MainActor.run { completion(.retry) }
+               } catch {
+                   AuthService.shared.logout()
+                   await MainActor.run { completion(.doNotRetry) }
+               }
           }
     }
 }

--- a/EATSSU/App/Sources/Data/Network/Foundation/TokenManager.swift
+++ b/EATSSU/App/Sources/Data/Network/Foundation/TokenManager.swift
@@ -11,7 +11,7 @@ struct TokenPayload: Decodable {
     let exp: TimeInterval
 }
 
-final class TokenManager {
+class TokenManager {
     static let shared = TokenManager()
     private init() {}
 
@@ -41,7 +41,7 @@ final class TokenManager {
     }
 
     /// JWT Payload 디코딩
-    private func decodePayload(token: String) -> TokenPayload? {
+    func decodePayload(token: String) -> TokenPayload? {
         let parts = token.split(separator: ".")
         guard parts.count == 3 else { return nil }
 

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
@@ -80,16 +80,7 @@ final class LoginViewController: BaseViewController {
             Analytics.logEvent("LoginViewControllerLoad", parameters: nil)
         #endif
     }
-
-    /// Realm에 저장된 토큰이 있는지 확인 후, 있으면 홈 화면으로 이동한다.
-//    private func handleAutoLogin() {
-//        guard hasStoredToken() else { return }
-//        // 토큰이 남아 있으면 AuthService에 로그인 상태로 알리고, SceneDelegate가 화면 전환을 담당하게
-//        let at = RealmService.shared.getToken()
-//        let rt = RealmService.shared.getRefreshToken()
-//        AuthService.shared.login(accessToken: at, refreshToken: rt)
-//    }
-
+    
     private func hasStoredToken() -> Bool {
         !RealmService.shared.getToken().isEmpty
     }
@@ -204,8 +195,6 @@ extension LoginViewController {
             // 3) 로컬 매니저에 유저 정보 생성
             _ = UserInfoManager.shared.createUserInfo(accountType: accountType)
 
-            // (닉네임 설정 화면으로 이동할 필요가 있으면, 아래 로직에서 분기 처리)
-//            getMyInfo()
         } catch {
             switch accountType {
             case .apple:
@@ -261,33 +250,6 @@ extension LoginViewController {
             }
         }
     }
-
-    /// 서버에서 현재 유저 정보를 조회
-//    private func getMyInfo() {
-//        print("[디버깅] getMyInfo() 호출됨") // ✅ 추가
-//
-//        myProvider.request(.myInfo) { [weak self] result in
-//            guard let self else { return }
-//            switch result {
-//            case let .success(moyaResponse):
-//                do {
-//                    print("[디버깅] myInfo API 응답 받음") // ✅ 추가
-//                    let responseData = try moyaResponse.map(BaseResponse<MyInfoResponse>.self)
-//                    guard let responseData = responseData.result else {
-//                        print("[디버깅] myInfo 결과 result가 nil임") // ✅ 추가
-//                        return
-//                    }
-//                    print("[디버깅] 닉네임 정보: \(responseData.nickname ?? "없음")") // ✅ 추가
-//                    handleNicknameCheck(info: responseData)
-//                } catch {
-//                    print("[디버깅] 디코딩 에러: \(error.localizedDescription)")
-//                }
-//            case let .failure(error):
-//                print("[디버깅] myInfo API 실패: \(error.localizedDescription)")
-//            }
-//        }
-//    }
-
 }
 
 // MARK: - 카카오 사용자 정보 가져오기

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
@@ -30,7 +30,8 @@ final class LoginViewController: BaseViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        handleAutoLogin()
+        showToastMessageIfNeeded()
+//        handleAutoLogin()
     }
 
     override func viewDidLoad() {
@@ -82,13 +83,13 @@ final class LoginViewController: BaseViewController {
     }
 
     /// Realm에 저장된 토큰이 있는지 확인 후, 있으면 홈 화면으로 이동한다.
-    private func handleAutoLogin() {
-        guard hasStoredToken() else { return }
-        #if DEBUG
-            print("저장된 AccessToken: ", RealmService.shared.getToken())
-        #endif
-        changeIntoHomeViewController()
-    }
+//    private func handleAutoLogin() {
+//        guard hasStoredToken() else { return }
+//        // 토큰이 남아 있으면 AuthService에 로그인 상태로 알리고, SceneDelegate가 화면 전환을 담당하게
+//        let at = RealmService.shared.getToken()
+//        let rt = RealmService.shared.getRefreshToken()
+//        AuthService.shared.login(accessToken: at, refreshToken: rt)
+//    }
 
     private func hasStoredToken() -> Bool {
         !RealmService.shared.getToken().isEmpty
@@ -108,17 +109,24 @@ final class LoginViewController: BaseViewController {
     /// 닉네임 설정이 필요한지 확인 후, 필요하면 닉네임 설정 화면으로, 아니면 홈 화면으로 이동한다.
     private func handleNicknameCheck(info: MyInfoResponse) {
         if let nickname = info.nickname {
-            // 사용자의 닉네임을 업데이트하고 홈 화면으로 이동
-            if let currentUserInfo = UserInfoManager.shared.getCurrentUserInfo() {
-                UserInfoManager.shared.updateNickname(for: currentUserInfo, nickname: nickname)
+            print("[디버깅] 닉네임 존재함: \(nickname)")
+
+            let currentUser = UserInfoManager.shared.getCurrentUserInfo()
+            print("[디버깅] currentUserInfo: \(String(describing: currentUser))")
+
+            if let u = currentUser {
+                UserInfoManager.shared.updateNickname(for: u, nickname: nickname)
+                print("[디버깅] 닉네임 업데이트 완료")
+            } else {
+                print("[디버깅] currentUserInfo가 nil임")
             }
-            changeIntoHomeViewController()
         } else {
-            // 닉네임 설정이 필요한 경우
+            print("[디버깅] 닉네임이 없음 → 닉네임 설정 화면으로 이동")
             let setNicknameVC = SetNickNameViewController()
             navigationController?.pushViewController(setNicknameVC, animated: true)
         }
     }
+
 
     /// 토큰을 Realm에 저장하고, 디버깅 로그를 출력한다.
     private func storeTokensAndPrintDebugLogs(accessToken: String, refreshToken: String) {
@@ -129,8 +137,9 @@ final class LoginViewController: BaseViewController {
     }
     
     private func showToastMessageIfNeeded() {
-        guard let toastMessage = self.toastMessage else { return }
-        view.showToast(message: toastMessage)
+        guard let message = toastMessage else { return }
+        view.showToast(message: message)
+        toastMessage = nil
     }
 
     // MARK: - 액션 메서드
@@ -172,7 +181,8 @@ final class LoginViewController: BaseViewController {
 
     @objc
     private func lookingWithNoSignInButtonDidTapped() {
-        changeIntoHomeViewController()
+        // 비로그인 모드 진입: 필요하다면 빈 토큰으로 로그인 상태만 세팅
+        AuthService.shared.login(accessToken: "", refreshToken: "")
     }
 }
 
@@ -192,14 +202,17 @@ extension LoginViewController {
             let accessToken = data.accessToken
             let refreshToken = data.refreshToken
                 
-            // 토큰을 로컬에 저장
+            // 1) 토큰 저장
             storeTokensAndPrintDebugLogs(accessToken: accessToken, refreshToken: refreshToken)
 
-            // 로컬 매니저에 유저 정보 생성
+            // 2) 인증 상태 업데이트 (SceneDelegate.observeAuthState가 화면 전환 처리)
+            AuthService.shared.login(accessToken: accessToken, refreshToken: refreshToken)  //
+
+            // 3) 로컬 매니저에 유저 정보 생성
             _ = UserInfoManager.shared.createUserInfo(accountType: accountType)
 
-            // 닉네임 등 정보를 확인하기 위해 프로필 조회
-            getMyInfo()
+            // (닉네임 설정 화면으로 이동할 필요가 있으면, 아래 로직에서 분기 처리)
+//            getMyInfo()
         } catch {
             switch accountType {
             case .apple:
@@ -257,25 +270,31 @@ extension LoginViewController {
     }
 
     /// 서버에서 현재 유저 정보를 조회
-    private func getMyInfo() {
-        myProvider.request(.myInfo) { [weak self] result in
-            guard let self else { return }
-            switch result {
-            case let .success(moyaResponse):
-                do {
-                    let responseData = try moyaResponse.map(BaseResponse<MyInfoResponse>.self)
-                    guard let responseData = responseData.result else {
-                        return
-                    }
-                    handleNicknameCheck(info: responseData)
-                } catch {
-                    print(error.localizedDescription)
-                }
-            case let .failure(error):
-                print(error.localizedDescription)
-            }
-        }
-    }
+//    private func getMyInfo() {
+//        print("[디버깅] getMyInfo() 호출됨") // ✅ 추가
+//
+//        myProvider.request(.myInfo) { [weak self] result in
+//            guard let self else { return }
+//            switch result {
+//            case let .success(moyaResponse):
+//                do {
+//                    print("[디버깅] myInfo API 응답 받음") // ✅ 추가
+//                    let responseData = try moyaResponse.map(BaseResponse<MyInfoResponse>.self)
+//                    guard let responseData = responseData.result else {
+//                        print("[디버깅] myInfo 결과 result가 nil임") // ✅ 추가
+//                        return
+//                    }
+//                    print("[디버깅] 닉네임 정보: \(responseData.nickname ?? "없음")") // ✅ 추가
+//                    handleNicknameCheck(info: responseData)
+//                } catch {
+//                    print("[디버깅] 디코딩 에러: \(error.localizedDescription)")
+//                }
+//            case let .failure(error):
+//                print("[디버깅] myInfo API 실패: \(error.localizedDescription)")
+//            }
+//        }
+//    }
+
 }
 
 // MARK: - 카카오 사용자 정보 가져오기

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
@@ -18,7 +18,6 @@ final class LoginViewController: BaseViewController {
     // MARK: - Properties
 
     public static let isVacationPeriod = false
-    public var toastMessage: String?
     private let authProvider = MoyaProvider<AuthRouter>(session: Session(interceptor: AuthInterceptor.shared))
     private let myProvider = MoyaProvider<MyRouter>(session: Session(interceptor: AuthInterceptor.shared))
 
@@ -28,11 +27,11 @@ final class LoginViewController: BaseViewController {
 
     // MARK: - Life Cycle
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        showToastMessageIfNeeded()
-//        handleAutoLogin()
-    }
+//    override func viewWillAppear(_ animated: Bool) {
+//        super.viewWillAppear(animated)
+//        showToastMessageIfNeeded()
+////        handleAutoLogin()
+//    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -135,12 +134,7 @@ final class LoginViewController: BaseViewController {
             print("⭐️⭐️ 토큰 저장 성공 ⭐️⭐️")
         #endif
     }
-    
-    private func showToastMessageIfNeeded() {
-        guard let message = toastMessage else { return }
-        view.showToast(message: message)
-        toastMessage = nil
-    }
+
 
     // MARK: - 액션 메서드
 

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
@@ -181,8 +181,7 @@ final class LoginViewController: BaseViewController {
 
     @objc
     private func lookingWithNoSignInButtonDidTapped() {
-        // 비로그인 모드 진입: 필요하다면 빈 토큰으로 로그인 상태만 세팅
-        AuthService.shared.login(accessToken: "", refreshToken: "")
+        changeIntoHomeViewController()
     }
 }
 

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/SetNickNameViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/SetNickNameViewController.swift
@@ -105,17 +105,6 @@ final class SetNickNameViewController: BaseViewController {
             currentKeyboardHeight = 0.0
         }
     }
-    
-//    private func navigateToLogin() {
-//        let loginVC = LoginViewController()
-//        loginVC.toastMessage = "세션이 만료되었습니다. 다시 로그인해주세요."
-//        DispatchQueue.main.async {
-//            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-//               let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) {
-//                keyWindow.replaceRootViewController(UINavigationController(rootViewController: loginVC))
-//            }
-//        }
-//    }
 }
 
 // MARK: - Network

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/SetNickNameViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/SetNickNameViewController.swift
@@ -106,16 +106,16 @@ final class SetNickNameViewController: BaseViewController {
         }
     }
     
-    private func navigateToLogin() {
-        let loginVC = LoginViewController()
-        loginVC.toastMessage = "세션이 만료되었습니다. 다시 로그인해주세요."
-        DispatchQueue.main.async {
-            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-               let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) {
-                keyWindow.replaceRootViewController(UINavigationController(rootViewController: loginVC))
-            }
-        }
-    }
+//    private func navigateToLogin() {
+//        let loginVC = LoginViewController()
+//        loginVC.toastMessage = "세션이 만료되었습니다. 다시 로그인해주세요."
+//        DispatchQueue.main.async {
+//            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+//               let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) {
+//                keyWindow.replaceRootViewController(UINavigationController(rootViewController: loginVC))
+//            }
+//        }
+//    }
 }
 
 // MARK: - Network
@@ -129,23 +129,17 @@ extension SetNickNameViewController {
                     UserInfoManager.shared.updateNickname(for: currentUserInfo, nickname: nickname)
                 }
                 self.showAlertController(title: "완료", message: "닉네임 설정이 완료되었습니다.", style: .cancel) {
-                    if let myPageViewController = self.navigationController?.viewControllers.first(where: { $0 is MyPageViewController }) {
-                        self.navigationController?.popToViewController(myPageViewController, animated: true)
-                    } else {
-                        let homeViewController = HomeViewController()
-                        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                           let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow })
-                        {
-                            keyWindow.replaceRootViewController(UINavigationController(rootViewController: homeViewController))
-                        }
-                    }
+                    // 인증 상태만 업데이트 → SceneDelegate.observeAuthState()가 Home으로 전환
+                    let at = RealmService.shared.getToken()
+                    let rt = RealmService.shared.getRefreshToken()
+                    AuthService.shared.login(accessToken: at, refreshToken: rt)
                 }
             
             case let .failure(err):
                 print(err.localizedDescription)
-                
+
                 RealmService.shared.resetDB()
-                self.navigateToLogin()
+                AuthService.shared.logout(message: "세션이 만료되었습니다. 다시 로그인해주세요.")
             }
         }
     }
@@ -174,13 +168,14 @@ extension SetNickNameViewController {
                     print(err.localizedDescription)
                     
                     RealmService.shared.resetDB()
-                    self.navigateToLogin()
+                    AuthService.shared.logout()
                 }
             case let .failure(err):
                 print(err.localizedDescription)
-                
+
                 RealmService.shared.resetDB()
-                self.navigateToLogin()
+                // message 파라미터 없는 logout 호출로 변경
+                AuthService.shared.logout()
             }
         }
     }

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/SetNickNameViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/SetNickNameViewController.swift
@@ -168,14 +168,13 @@ extension SetNickNameViewController {
                     print(err.localizedDescription)
                     
                     RealmService.shared.resetDB()
-                    AuthService.shared.logout()
+                    AuthService.shared.logout(message: "세션이 만료되었습니다. 다시 로그인해주세요.")
                 }
             case let .failure(err):
                 print(err.localizedDescription)
-
+                
                 RealmService.shared.resetDB()
-                // message 파라미터 없는 logout 호출로 변경
-                AuthService.shared.logout()
+                AuthService.shared.logout(message: "세션이 만료되었습니다. 다시 로그인해주세요.")
             }
         }
     }

--- a/EATSSU/App/Sources/Presentation/Home/ViewController/HomeViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Home/ViewController/HomeViewController.swift
@@ -104,7 +104,6 @@ final class HomeViewController: BaseViewController {
         if AuthService.shared.isTokenValid() {
             navigateToMyPage()
         } else {
-            AuthService.shared.logout()
             presentLoginAlert()
         }
     }
@@ -115,16 +114,19 @@ final class HomeViewController: BaseViewController {
     }
 
     private func presentLoginAlert() {
-        let alert = UIAlertController(title: "로그인이 필요한 서비스입니다",
-                                      message: "로그인 하시겠습니까?",
-                                      preferredStyle: .alert)
-        let confirmAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
-            self?.navigateToLogin()
+        let alert = UIAlertController(
+            title: "로그인이 필요한 서비스입니다",
+            message: "로그인 하시겠습니까?",
+            preferredStyle: .alert
+        )
+        let confirm = UIAlertAction(title: "확인", style: .default) { _ in
+            AuthService.shared.logout()
+            self.navigateToLogin()
         }
-        let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
-        alert.addAction(confirmAction)
-        alert.addAction(cancelAction)
-        present(alert, animated: true, completion: nil)
+        let cancel = UIAlertAction(title: "취소", style: .cancel)
+        alert.addAction(confirm)
+        alert.addAction(cancel)
+        present(alert, animated: true)
     }
 
     private func navigateToLogin() {

--- a/EATSSU/App/Sources/Presentation/Home/ViewController/HomeViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Home/ViewController/HomeViewController.swift
@@ -101,9 +101,10 @@ final class HomeViewController: BaseViewController {
 
     @objc
     private func didTapRightBarButton() {
-        if RealmService.shared.isAccessTokenPresent() {
+        if AuthService.shared.isTokenValid() {
             navigateToMyPage()
         } else {
+            AuthService.shared.logout()
             presentLoginAlert()
         }
     }
@@ -118,7 +119,7 @@ final class HomeViewController: BaseViewController {
                                       message: "로그인 하시겠습니까?",
                                       preferredStyle: .alert)
         let confirmAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
-            AuthService.shared.logout()
+            self?.navigateToLogin()
         }
         let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
         alert.addAction(confirmAction)
@@ -126,15 +127,15 @@ final class HomeViewController: BaseViewController {
         present(alert, animated: true, completion: nil)
     }
 
-//    private func navigateToLogin() {
-//        let loginVC = LoginViewController()
-//        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-//           let sceneDelegate = windowScene.delegate as? SceneDelegate,
-//           let window = sceneDelegate.window
-//        {
-//            window.replaceRootViewController(loginVC)
-//        }
-//    }
+    private func navigateToLogin() {
+        let loginVC = LoginViewController()
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let sceneDelegate = windowScene.delegate as? SceneDelegate,
+           let window = sceneDelegate.window
+        {
+            window.replaceRootViewController(loginVC)
+        }
+    }
 
     // MARK: - Firebase
 

--- a/EATSSU/App/Sources/Presentation/Home/ViewController/HomeViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Home/ViewController/HomeViewController.swift
@@ -118,7 +118,7 @@ final class HomeViewController: BaseViewController {
                                       message: "로그인 하시겠습니까?",
                                       preferredStyle: .alert)
         let confirmAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
-            self?.navigateToLogin()
+            AuthService.shared.logout()
         }
         let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
         alert.addAction(confirmAction)
@@ -126,15 +126,15 @@ final class HomeViewController: BaseViewController {
         present(alert, animated: true, completion: nil)
     }
 
-    private func navigateToLogin() {
-        let loginVC = LoginViewController()
-        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let sceneDelegate = windowScene.delegate as? SceneDelegate,
-           let window = sceneDelegate.window
-        {
-            window.replaceRootViewController(loginVC)
-        }
-    }
+//    private func navigateToLogin() {
+//        let loginVC = LoginViewController()
+//        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+//           let sceneDelegate = windowScene.delegate as? SceneDelegate,
+//           let window = sceneDelegate.window
+//        {
+//            window.replaceRootViewController(loginVC)
+//        }
+//    }
 
     // MARK: - Firebase
 

--- a/EATSSU/App/Sources/Presentation/Home/ViewController/HomeViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Home/ViewController/HomeViewController.swift
@@ -120,7 +120,7 @@ final class HomeViewController: BaseViewController {
             preferredStyle: .alert
         )
         let confirm = UIAlertAction(title: "확인", style: .default) { _ in
-            AuthService.shared.logout()
+            AuthService.shared.logout(message: nil)
             self.navigateToLogin()
         }
         let cancel = UIAlertAction(title: "취소", style: .cancel)

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -41,8 +41,9 @@ final class MyPageViewController: BaseViewController {
 
         nickName = UserInfoManager.shared.getCurrentUserInfo()?.nickname ?? "실패"
         mypageView.setUserInfo(nickname: nickName)
+        showToastMessageIfNeeded()
     }
-
+    
     // MARK: - Functions
 
     override func setCustomNavigationBar() {
@@ -106,7 +107,7 @@ final class MyPageViewController: BaseViewController {
         let cancelAction = UIAlertAction(title: "취소하기", style: .default, handler: nil)
 
         let fixAction = UIAlertAction(title: "로그아웃", style: .default) { _ in
-            AuthService.shared.logout()
+            AuthService.shared.logout(message: "로그아웃이 완료되었습니다.")
         }
 
         alert.addAction(cancelAction)

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -107,7 +107,7 @@ final class MyPageViewController: BaseViewController {
         let cancelAction = UIAlertAction(title: "취소하기", style: .default, handler: nil)
 
         let fixAction = UIAlertAction(title: "로그아웃", style: .default) { _ in
-            AuthService.shared.logout(message: "로그아웃이 완료되었습니다.")
+            AuthService.shared.logout()
         }
 
         alert.addAction(cancelAction)

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -43,7 +43,7 @@ final class MyPageViewController: BaseViewController {
         mypageView.setUserInfo(nickname: nickName)
         showToastMessageIfNeeded()
     }
-    
+     
     // MARK: - Functions
 
     override func setCustomNavigationBar() {

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -107,7 +107,7 @@ final class MyPageViewController: BaseViewController {
         let cancelAction = UIAlertAction(title: "취소하기", style: .default, handler: nil)
 
         let fixAction = UIAlertAction(title: "로그아웃", style: .default) { _ in
-            AuthService.shared.logout()
+            AuthService.shared.logout(message: nil)
         }
 
         alert.addAction(cancelAction)

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -97,26 +97,17 @@ final class MyPageViewController: BaseViewController {
 
     /// 로그아웃 Alert를 스크린에 표시하는 메소드
     private func logoutShowAlert() {
-        let alert = UIAlertController(title: "로그아웃",
-                                      message: "정말 로그아웃 하시겠습니까?",
-                                      preferredStyle: UIAlertController.Style.alert)
+        let alert = UIAlertController(
+            title: "로그아웃",
+            message: "정말 로그아웃 하시겠습니까?",
+            preferredStyle: .alert
+        )
 
-        let cancelAction = UIAlertAction(title: "취소하기",
-                                         style: .default,
-                                         handler: nil)
+        let cancelAction = UIAlertAction(title: "취소하기", style: .default, handler: nil)
 
-        let fixAction = UIAlertAction(title: "로그아웃",
-                                      style: .default,
-                                      handler: { _ in
-                                          RealmService.shared.resetDB()
-
-                                          let loginViewController = LoginViewController()
-                                          if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                                             let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow })
-                                          {
-                                              keyWindow.replaceRootViewController(UINavigationController(rootViewController: loginViewController))
-                                          }
-                                      })
+        let fixAction = UIAlertAction(title: "로그아웃", style: .default) { _ in
+            AuthService.shared.logout()
+        }
 
         alert.addAction(cancelAction)
         alert.addAction(fixAction)

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
@@ -121,16 +121,16 @@ final class MyReviewViewController: BaseViewController {
         }
     }
     
-    private func navigateToLogin() {
-        let loginVC = LoginViewController()
-        loginVC.toastMessage = "세션이 만료되었습니다. 다시 로그인해주세요."
-        DispatchQueue.main.async {
-            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-               let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) {
-                keyWindow.replaceRootViewController(UINavigationController(rootViewController: loginVC))
-            }
-        }
-    }
+//    private func navigateToLogin() {
+//        let loginVC = LoginViewController()
+//        loginVC.toastMessage = "세션이 만료되었습니다. 다시 로그인해주세요."
+//        DispatchQueue.main.async {
+//            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+//               let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) {
+//                keyWindow.replaceRootViewController(UINavigationController(rootViewController: loginVC))
+//            }
+//        }
+//    }
 }
 
 extension MyReviewViewController: UITableViewDelegate {}
@@ -171,13 +171,13 @@ extension MyReviewViewController {
                     print(err.localizedDescription)
                     
                     RealmService.shared.resetDB()
-                    self.navigateToLogin()
+                    AuthService.shared.logout(message: "세션이 만료되었습니다. 다시 로그인해주세요.")
                 }
             case let .failure(err):
                 print(err.localizedDescription)
                 
                 RealmService.shared.resetDB()
-                self.navigateToLogin()
+                AuthService.shared.logout(message: "세션이 만료되었습니다. 다시 로그인해주세요.")
             }
         }
     }
@@ -194,7 +194,7 @@ extension MyReviewViewController {
                     print(err.localizedDescription)
                     
                     RealmService.shared.resetDB()
-                    self.navigateToLogin()
+                    AuthService.shared.logout(message: "세션이 만료되었습니다. 다시 로그인해주세요.")
                 }
             }
         })

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
@@ -120,17 +120,6 @@ final class MyReviewViewController: BaseViewController {
             noMyReviewImageView.isHidden = true
         }
     }
-    
-//    private func navigateToLogin() {
-//        let loginVC = LoginViewController()
-//        loginVC.toastMessage = "세션이 만료되었습니다. 다시 로그인해주세요."
-//        DispatchQueue.main.async {
-//            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-//               let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) {
-//                keyWindow.replaceRootViewController(UINavigationController(rootViewController: loginVC))
-//            }
-//        }
-//    }
 }
 
 extension MyReviewViewController: UITableViewDelegate {}

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/UserWithdrawViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/UserWithdrawViewController.swift
@@ -129,15 +129,9 @@ extension UserWithdrawViewController {
                 do {
                     let responseData = try moyaResponse.map(BaseResponse<Bool>.self)
                     guard let data = responseData.result, data else { return }
-                    
+
                     RealmService.shared.resetDB()
-                    let loginViewController = LoginViewController()
-                    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                       let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow })
-                    {
-                        loginViewController.toastMessage = "탈퇴 처리가 완료되었습니다."
-                        keyWindow.replaceRootViewController(UINavigationController(rootViewController: loginViewController))
-                    }
+                    AuthService.shared.logout(message: "탈퇴 처리가 완료되었습니다.")
                 } catch let err {
                     print(err.localizedDescription)
                 }

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/ReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/ReviewViewController.swift
@@ -198,7 +198,7 @@ final class ReviewViewController: BaseViewController {
                     preferredStyle: .alert
                 )
                 let confirm = UIAlertAction(title: "확인", style: .default) { _ in
-                    AuthService.shared.logout()
+                    AuthService.shared.logout(message: nil)
                     self.navigateToLogin()
                 }
                 let cancel = UIAlertAction(title: "취소", style: .cancel)

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/ReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/ReviewViewController.swift
@@ -189,44 +189,52 @@ final class ReviewViewController: BaseViewController {
 
     //    @objc
     func userTapReviewButton() {
-        if AuthService.shared.isTokenValid() {
+        _Concurrency.Task {
+            let valid = await AuthService.shared.checkAndRefreshTokenIfNeeded()
+            if !valid {
+                let alert = UIAlertController(
+                    title: "로그인이 필요한 서비스입니다",
+                    message: "로그인 하시겠습니까?",
+                    preferredStyle: .alert
+                )
+                let confirm = UIAlertAction(title: "확인", style: .default) { _ in
+                    AuthService.shared.logout()
+                    self.navigateToLogin()
+                }
+                let cancel = UIAlertAction(title: "취소", style: .cancel)
+                alert.addAction(confirm)
+                alert.addAction(cancel)
+                self.present(alert, animated: true)
+                return
+            }
+            // 토큰 유효 시 기존 리뷰 작성 로직
             activityIndicatorView.isHidden = false
-            DispatchQueue.global().async { // 백그라운드 스레드에서 작업을 수행
-                // 작업 완료 후 UI 업데이트를 메인 스레드에서 수행
-                DispatchQueue.main.async { [self] in
-                    // 고정메뉴인지 판별(메뉴 ID List에 nil값 들어옴)
-                    if menuIDList == nil {
-                        let setRateViewController = SetRateViewController()
-                        menuIDList = [menuID]
-                        setRateViewController.dataBind(list: menuNameList,
-                                                       idList: menuIDList ?? [],
-                                                       reviewList: nil,
-                                                       currentPage: 0)
-                        activityIndicatorView.stopAnimating()
-                        navigationController?.pushViewController(setRateViewController, animated: true)
+            DispatchQueue.global().async {
+                DispatchQueue.main.async {
+                    if self.menuIDList == nil {
+                        let vc = SetRateViewController()
+                        self.menuIDList = [self.menuID]
+                        vc.dataBind(list: self.menuNameList,
+                                    idList: self.menuIDList ?? [],
+                                    reviewList: nil,
+                                    currentPage: 0)
+                        self.activityIndicatorView.stopAnimating()
+                        self.navigationController?.pushViewController(vc, animated: true)
+                    } else if self.menuIDList?.count == 1 {
+                        let vc = SetRateViewController()
+                        vc.dataBind(list: self.menuNameList,
+                                    idList: self.menuIDList ?? [],
+                                    reviewList: nil,
+                                    currentPage: 0)
+                        self.activityIndicatorView.stopAnimating()
+                        self.navigationController?.pushViewController(vc, animated: true)
                     } else {
-                        // 고정메뉴이고, 메뉴가 1개일때 선택창으로 안가고 바로 작성창으로 가도록
-                        if menuIDList?.count == 1 {
-                            let setRateViewController = SetRateViewController()
-                            setRateViewController.dataBind(list: menuNameList,
-                                                           idList: menuIDList ?? [],
-                                                           reviewList: nil,
-                                                           currentPage: 0)
-                            activityIndicatorView.stopAnimating()
-                            navigationController?.pushViewController(setRateViewController, animated: true)
-                        } else {
-                            let choiceMenuViewController = ChoiceMenuViewController()
-                            choiceMenuViewController.menuDataBind(menuList: menuNameList, idList: menuIDList ?? [])
-                            activityIndicatorView.stopAnimating()
-                            navigationController?.pushViewController(choiceMenuViewController, animated: true)
-                        }
+                        let vc = ChoiceMenuViewController()
+                        vc.menuDataBind(menuList: self.menuNameList, idList: self.menuIDList ?? [])
+                        self.activityIndicatorView.stopAnimating()
+                        self.navigationController?.pushViewController(vc, animated: true)
                     }
                 }
-            }
-        } else {
-            AuthService.shared.logout()
-            showAlertControllerWithCancel(title: "로그인이 필요한 서비스입니다", message: "로그인 하시겠습니까?", confirmStyle: .default) {
-                self.navigateToLogin()
             }
         }
     }

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/ReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/ReviewViewController.swift
@@ -225,7 +225,7 @@ final class ReviewViewController: BaseViewController {
             }
         } else {
             showAlertControllerWithCancel(title: "로그인이 필요한 서비스입니다", message: "로그인 하시겠습니까?", confirmStyle: .default) {
-                self.pushToLoginVC()
+                AuthService.shared.logout()
             }
         }
     }

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/ReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/ReviewViewController.swift
@@ -189,7 +189,7 @@ final class ReviewViewController: BaseViewController {
 
     //    @objc
     func userTapReviewButton() {
-        if RealmService.shared.isAccessTokenPresent() {
+        if AuthService.shared.isTokenValid() {
             activityIndicatorView.isHidden = false
             DispatchQueue.global().async { // 백그라운드 스레드에서 작업을 수행
                 // 작업 완료 후 UI 업데이트를 메인 스레드에서 수행
@@ -224,15 +224,21 @@ final class ReviewViewController: BaseViewController {
                 }
             }
         } else {
+            AuthService.shared.logout()
             showAlertControllerWithCancel(title: "로그인이 필요한 서비스입니다", message: "로그인 하시겠습니까?", confirmStyle: .default) {
-                AuthService.shared.logout()
+                self.navigateToLogin()
             }
         }
     }
 
-    private func pushToLoginVC() {
+    private func navigateToLogin() {
         let loginVC = LoginViewController()
-        navigationController?.pushViewController(loginVC, animated: true)
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let sceneDelegate = windowScene.delegate as? SceneDelegate,
+           let window = sceneDelegate.window
+        {
+            window.replaceRootViewController(loginVC)
+        }
     }
 
     func makeDictionary() {

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
@@ -520,17 +520,6 @@ extension SetRateViewController {
             }
         }
     }
-    
-//    private func navigateToLogin() {
-//        let loginVC = LoginViewController()
-//        loginVC.toastMessage = "세션이 만료되었습니다. 다시 로그인해주세요."
-//        DispatchQueue.main.async {
-//            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-//               let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) {
-//                keyWindow.replaceRootViewController(UINavigationController(rootViewController: loginVC))
-//            }
-//        }
-//    }
 }
 
 // MARK: - UIImagePickerControllerDelegate

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
@@ -500,7 +500,7 @@ extension SetRateViewController {
                 debugPrint(err.localizedDescription)
                 
                 RealmService.shared.resetDB()
-                self.navigateToLogin()
+                AuthService.shared.logout(message: "세션이 만료되었습니다. 다시 로그인해주세요.")
             }
         }
     }
@@ -516,21 +516,21 @@ extension SetRateViewController {
                 print(err.localizedDescription)
                 
                 RealmService.shared.resetDB()
-                self.navigateToLogin()
+                AuthService.shared.logout(message: "세션이 만료되었습니다. 다시 로그인해주세요.")
             }
         }
     }
     
-    private func navigateToLogin() {
-        let loginVC = LoginViewController()
-        loginVC.toastMessage = "세션이 만료되었습니다. 다시 로그인해주세요."
-        DispatchQueue.main.async {
-            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-               let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) {
-                keyWindow.replaceRootViewController(UINavigationController(rootViewController: loginVC))
-            }
-        }
-    }
+//    private func navigateToLogin() {
+//        let loginVC = LoginViewController()
+//        loginVC.toastMessage = "세션이 만료되었습니다. 다시 로그인해주세요."
+//        DispatchQueue.main.async {
+//            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+//               let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) {
+//                keyWindow.replaceRootViewController(UINavigationController(rootViewController: loginVC))
+//            }
+//        }
+//    }
 }
 
 // MARK: - UIImagePickerControllerDelegate

--- a/EATSSU/App/Sources/Services/AuthService.swift
+++ b/EATSSU/App/Sources/Services/AuthService.swift
@@ -1,0 +1,62 @@
+//
+//  AuthService.swift
+//  EATSSU-DEV
+//
+//  Created by 황상환 on 8/5/25.
+
+import Foundation
+import RxSwift
+import RxRelay
+
+enum AuthError: Error {
+    case tokenExpired
+}
+
+/// 인증 상태 및 토큰 관리 서비스
+final class AuthService {
+    static let shared = AuthService()
+    private let disposeBag = DisposeBag()
+    private let relay = BehaviorRelay<Bool>(value: false)
+
+    /// 인증 상태 스트림
+    var isAuthenticated: Observable<Bool> {
+        relay.asObservable()
+    }
+
+    private init() {
+        Task {
+            do {
+                try await self.checkToken()
+            } catch {
+                self.logout()
+            }
+        }
+    }
+
+    /// 로그인 처리
+    func login(accessToken: String, refreshToken: String) {
+        RealmService.shared.addToken(
+            accessToken: accessToken,
+            refreshToken: refreshToken
+        )
+        relay.accept(true)
+    }
+
+    /// 로그아웃 처리
+    func logout() {
+        RealmService.shared.deleteAll(Token.self)
+        relay.accept(false)
+    }
+
+    /// 토큰 유효성 검사 및 재발급
+    func checkToken() async throws {
+        let token = RealmService.shared.getToken()
+        guard let payload = TokenManager.shared.decodePayload(token: token),
+              Date(timeIntervalSince1970: payload.exp) > Date() else {
+            throw AuthError.tokenExpired
+        }
+
+        try await TokenRefresher.shared.refreshIfNeeded()
+        relay.accept(true)
+    }
+}

--- a/EATSSU/App/Sources/Services/AuthService.swift
+++ b/EATSSU/App/Sources/Services/AuthService.swift
@@ -18,51 +18,68 @@ final class AuthService {
     static let shared = AuthService()
     private let disposeBag = DisposeBag()
     private let relay = BehaviorRelay<Bool>(value: false)
+    let logoutMessageRelay = PublishRelay<String?>()
 
-    /// 인증 상태 스트림
-    var isAuthenticated: Observable<Bool> {
-        relay.asObservable()
-    }
-
+    var isAuthenticated: BehaviorRelay<Bool> { relay }
+    
     private init() {
-        Task {
-            do {
-                try await self.checkToken()
-            } catch {
-                self.logout()
-            }
-        }
+        let hasToken = isTokenValid()
+        relay.accept(hasToken)
     }
 
-    /// 로그인 처리
     func login(accessToken: String, refreshToken: String) {
         print("[AuthService] login() 호출됨")
-        RealmService.shared.addToken(
-            accessToken: accessToken,
-            refreshToken: refreshToken
-        )
+        RealmService.shared.addToken(accessToken: accessToken, refreshToken: refreshToken)
         relay.accept(true)
     }
 
-    /// 로그아웃 처리
-    func logout() {
+    func logout(message: String? = nil) {
         print("[AuthService] logout() 호출됨")
         RealmService.shared.deleteAll(Token.self)
+        if let message = message {
+            logoutMessageRelay.accept(message)
+        }
         relay.accept(false)
     }
+    
+    var logoutMessage: Observable<String?> {
+        logoutMessageRelay.asObservable()
+    }
 
-    /// 토큰 유효성 검사 및 재발급
-    func checkToken() async throws {
-        print("[AuthService] checkToken() 시작")
+
+    func isTokenValid() -> Bool {
         let token = RealmService.shared.getToken()
-        guard let payload = TokenManager.shared.decodePayload(token: token),
-              Date(timeIntervalSince1970: payload.exp) > Date() else {
-            print("[AuthService] checkToken() 실패 → 토큰 만료됨")
-            throw AuthError.tokenExpired
+        guard let payload = TokenManager.shared.decodePayload(token: token) else {
+            print("[AuthService] 디코딩 실패")
+            return false
+        }
+        print("[AuthService] exp: \(payload.exp), now: \(Date().timeIntervalSince1970)")
+        return Date(timeIntervalSince1970: payload.exp) > Date()
+    }
+
+    func checkAndRefreshTokenIfNeeded() async -> Bool {
+        print("[AuthService] checkAndRefreshTokenIfNeeded() 시작")
+
+        let token = RealmService.shared.getToken()
+        guard let payload = TokenManager.shared.decodePayload(token: token) else {
+            print("[AuthService] 디코딩 실패")
+            return false
+        }
+        print("[AuthService] exp: \(payload.exp), now: \(Date().timeIntervalSince1970)")
+
+        // 만료됐어도 isTokenExpiringSoon()이 true이므로 재발급 시도
+        if TokenManager.shared.isTokenExpiringSoon() {
+            do {
+                try await TokenRefresher.shared.refreshIfNeeded()
+                print("[AuthService] 토큰 재발급 성공")
+            } catch {
+                print("[AuthService] 토큰 재발급 실패")
+                return false
+            }
         }
 
-        try await TokenRefresher.shared.refreshIfNeeded()
-        print("[AuthService] checkToken() 성공 → 토큰 유효")
+        // 재발급 성공 또는 아직 유효하다면 로그인 상태로 전환
         relay.accept(true)
+        return true
     }
 }

--- a/EATSSU/App/Sources/Services/AuthService.swift
+++ b/EATSSU/App/Sources/Services/AuthService.swift
@@ -36,8 +36,11 @@ final class AuthService {
     func logout(message: String? = nil) {
         print("[AuthService] logout() 호출됨")
         RealmService.shared.deleteAll(Token.self)
+
         if let message = message {
             logoutMessageRelay.accept(message)
+        } else {
+            logoutMessageRelay.accept(nil)
         }
         relay.accept(false)
     }

--- a/EATSSU/App/Sources/Services/AuthService.swift
+++ b/EATSSU/App/Sources/Services/AuthService.swift
@@ -5,6 +5,7 @@
 //  Created by 황상환 on 8/5/25.
 
 import Foundation
+
 import RxSwift
 import RxRelay
 

--- a/EATSSU/App/Sources/Services/AuthService.swift
+++ b/EATSSU/App/Sources/Services/AuthService.swift
@@ -9,19 +9,17 @@ import Foundation
 import RxSwift
 import RxRelay
 
-enum AuthError: Error {
-    case tokenExpired
-}
-
 /// 인증 상태 및 토큰 관리 서비스
 final class AuthService {
     static let shared = AuthService()
     private let disposeBag = DisposeBag()
     private let relay = BehaviorRelay<Bool>(value: false)
-    let logoutMessageRelay = PublishRelay<String?>()
+    private let logoutMessageRelay = BehaviorRelay<String?>(value: nil)
 
-    var isAuthenticated: BehaviorRelay<Bool> { relay }
-    
+    var isAuthenticated: Observable<Bool> {
+      relay.asObservable()
+    }
+
     private init() {
         let hasToken = isTokenValid()
         relay.accept(hasToken)
@@ -30,6 +28,7 @@ final class AuthService {
     func login(accessToken: String, refreshToken: String) {
         print("[AuthService] login() 호출됨")
         RealmService.shared.addToken(accessToken: accessToken, refreshToken: refreshToken)
+        relay.accept(false)
         relay.accept(true)
     }
 
@@ -46,10 +45,10 @@ final class AuthService {
         logoutMessageRelay.asObservable()
     }
 
-
     func isTokenValid() -> Bool {
         let token = RealmService.shared.getToken()
         guard let payload = TokenManager.shared.decodePayload(token: token) else {
+            logout()
             print("[AuthService] 디코딩 실패")
             return false
         }
@@ -62,6 +61,7 @@ final class AuthService {
 
         let token = RealmService.shared.getToken()
         guard let payload = TokenManager.shared.decodePayload(token: token) else {
+            logout()
             print("[AuthService] 디코딩 실패")
             return false
         }
@@ -73,6 +73,7 @@ final class AuthService {
                 try await TokenRefresher.shared.refreshIfNeeded()
                 print("[AuthService] 토큰 재발급 성공")
             } catch {
+                logout(message: "세션이 만료되었습니다. 다시 로그인해주세요.")
                 print("[AuthService] 토큰 재발급 실패")
                 return false
             }

--- a/EATSSU/App/Sources/Services/AuthService.swift
+++ b/EATSSU/App/Sources/Services/AuthService.swift
@@ -28,6 +28,8 @@ final class AuthService {
     func login(accessToken: String, refreshToken: String) {
         print("[AuthService] login() 호출됨")
         RealmService.shared.addToken(accessToken: accessToken, refreshToken: refreshToken)
+        logoutMessageRelay.accept(nil)
+        relay.accept(false)
         relay.accept(true)
     }
 

--- a/EATSSU/App/Sources/Services/AuthService.swift
+++ b/EATSSU/App/Sources/Services/AuthService.swift
@@ -28,7 +28,6 @@ final class AuthService {
     func login(accessToken: String, refreshToken: String) {
         print("[AuthService] login() 호출됨")
         RealmService.shared.addToken(accessToken: accessToken, refreshToken: refreshToken)
-        relay.accept(false)
         relay.accept(true)
     }
 

--- a/EATSSU/App/Sources/Services/AuthService.swift
+++ b/EATSSU/App/Sources/Services/AuthService.swift
@@ -36,6 +36,7 @@ final class AuthService {
 
     /// 로그인 처리
     func login(accessToken: String, refreshToken: String) {
+        print("[AuthService] login() 호출됨")
         RealmService.shared.addToken(
             accessToken: accessToken,
             refreshToken: refreshToken
@@ -45,19 +46,23 @@ final class AuthService {
 
     /// 로그아웃 처리
     func logout() {
+        print("[AuthService] logout() 호출됨")
         RealmService.shared.deleteAll(Token.self)
         relay.accept(false)
     }
 
     /// 토큰 유효성 검사 및 재발급
     func checkToken() async throws {
+        print("[AuthService] checkToken() 시작")
         let token = RealmService.shared.getToken()
         guard let payload = TokenManager.shared.decodePayload(token: token),
               Date(timeIntervalSince1970: payload.exp) > Date() else {
+            print("[AuthService] checkToken() 실패 → 토큰 만료됨")
             throw AuthError.tokenExpired
         }
 
         try await TokenRefresher.shared.refreshIfNeeded()
+        print("[AuthService] checkToken() 성공 → 토큰 유효")
         relay.accept(true)
     }
 }

--- a/EATSSU/App/Sources/Services/UserInfoService.swift
+++ b/EATSSU/App/Sources/Services/UserInfoService.swift
@@ -1,0 +1,69 @@
+//
+//  UserInfoService.swift
+//  EATSSU
+//
+//  Created by 황상환 on 8/6/25.
+//
+
+import Foundation
+import Moya
+import RealmSwift
+
+final class UserInfoService {
+    static let shared = UserInfoService()
+
+    private let provider = MoyaProvider<MyRouter>(session: Session(interceptor: AuthInterceptor.shared))
+
+    private init() {}
+
+    /// 서버에서 유저 정보를 조회하고, nickname이 있으면 UserInfoManager에 저장
+    func fetchAndUpdateUserInfo(completion: (() -> Void)? = nil) {
+        print("[UserInfoService] 유저 정보 조회 시작")
+
+        provider.request(.myInfo) { result in
+            switch result {
+            case let .success(response):
+                do {
+                    let responseData = try response.map(BaseResponse<MyInfoResponse>.self)
+                    guard let data = responseData.result else {
+                        print("[UserInfoService] result가 nil임")
+                        return
+                    }
+
+                    if let nickname = data.nickname {
+                        print("[UserInfoService] 닉네임: \(nickname)")
+
+                        if let _ = UserInfoManager.shared.getCurrentUserInfo() {
+                            DispatchQueue.global(qos: .userInitiated).async {
+                                autoreleasepool {
+                                    let realm = try! Realm()
+                                    guard let user = realm.objects(UserInfo.self).first else {
+                                        print("[UserInfoService] 백그라운드에서 user 조회 실패")
+                                        return
+                                    }
+
+                                    try! realm.write {
+                                        user.nickname = nickname
+                                    }
+
+                                    print("[UserInfoService] 닉네임 업데이트 완료 (Realm 백그라운드)")
+                                }
+                            }
+                        } else {
+                            print("[UserInfoService] currentUserInfo가 nil임")
+                        }
+                    } else {
+                        print("[UserInfoService] 닉네임이 없음 → 설정이 필요한 유저")
+                    }
+
+                    completion?()
+                } catch {
+                    print("[UserInfoService] 디코딩 실패: \(error.localizedDescription)")
+                }
+
+            case let .failure(error):
+                print("[UserInfoService] 요청 실패: \(error.localizedDescription)")
+            }
+        }
+    }
+}

--- a/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
@@ -22,7 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         handleAppleSignIn()
         initializeKakaoSDK()
         setupDebugConfigurations()
-        TokenManager.refreshIfNeededAsync()
+        
         UNUserNotificationCenter.current().delegate = self
 
         return true

--- a/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
@@ -28,9 +28,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = splashVC
         window?.makeKeyAndVisible()
         
-        observeAuthState()
-        fetchNoticeAndConfigureRootViewController()
-        checkForAppUpdate()
+        Task {
+            let ok = await AuthService.shared.checkAndRefreshTokenIfNeeded()
+            // relay.accept(true/false) 가 이미 호출된 뒤에 구독 시작
+            await MainActor.run {
+                self.observeAuthState()
+                self.fetchNoticeAndConfigureRootViewController()
+                self.checkForAppUpdate()
+            }
+        }
     }
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
@@ -140,35 +146,53 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // MARK: - RootViewController & Update
 
     private func observeAuthState() {
+        print("[observeAuthState] Auth 상태 구독 시작")
+
         AuthService.shared.isAuthenticated
+            .distinctUntilChanged()
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] isAuth in
-                guard let self = self else { return }
-                if isAuth {
-                    self.window?.rootViewController = HomeViewController()
-                } else {
-                    let loginVC = LoginViewController()
-                    self.window?.rootViewController = UINavigationController(rootViewController: loginVC)
+                guard let self = self else {
+                    print("[observeAuthState] self가 nil입니다. 종료")
+                    return
                 }
+
+                print("[observeAuthState] isAuthenticated 상태 변경 감지: \(isAuth)")
+
+                let vc: UIViewController
+
+                if isAuth {
+                    print("[observeAuthState] 로그인 상태 → HomeViewController 생성")
+                    UserInfoService.shared.fetchAndUpdateUserInfo()
+                    let homeVC = HomeViewController()
+                    vc = UINavigationController(rootViewController: homeVC)
+                } else {
+                    print("[observeAuthState] 비로그인 상태 → LoginViewController 생성")
+                    let loginVC = LoginViewController()
+                    vc = UINavigationController(rootViewController: loginVC)
+                }
+
+                print("[observeAuthState] 루트 뷰컨트롤러 변경 적용")
+                self.window?.rootViewController = vc
             })
             .disposed(by: disposeBag)
     }
+
     
     private func fetchNoticeAndConfigureRootViewController() {
         FirebaseRemoteConfig.shared.noticeCheck { [weak self] result in
+            // result가 nil이면 노티스가 없는 경우이므로 아무 동작도 하지 않음
+            guard let self = self, let notice = result, !notice.isEmpty else { return }
             DispatchQueue.main.async {
-                self?.configureRootViewController(with: result)
+                // 공지 문구가 있을 때만 루트 교체
+                self.configureRootViewController(with: notice)
             }
         }
     }
 
-    private func configureRootViewController(with noticeMessage: String?) {
-        let rootViewController: UIViewController = if let notice = noticeMessage, !notice.isEmpty {
-            UINavigationController(rootViewController: NoticeViewController(noticeMessage: notice))
-        } else {
-            UINavigationController(rootViewController: LoginViewController())
-        }
-        window?.rootViewController = rootViewController
+    private func configureRootViewController(with noticeMessage: String) {
+        let newRoot = UINavigationController(rootViewController: NoticeViewController(noticeMessage: noticeMessage))
+        window?.rootViewController = newRoot
     }
 
     private func checkForAppUpdate() {

--- a/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
@@ -28,15 +28,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = splashVC
         window?.makeKeyAndVisible()
         
-        Task {
-            _ = await AuthService.shared.checkAndRefreshTokenIfNeeded()
-            // relay.accept(true/false) 가 이미 호출된 뒤에 구독 시작
-            await MainActor.run {
-                self.observeAuthState()
-                self.fetchNoticeAndConfigureRootViewController()
-                self.checkForAppUpdate()
-            }
-        }
+        performInitialTasks()
     }
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
@@ -143,6 +135,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         LaunchSourceManager.shared.logIfNeeded()
     }
 
+    // MARK: - Initial Async Tasks
+
+    private func performInitialTasks() {
+        Task {
+            _ = await AuthService.shared.checkAndRefreshTokenIfNeeded()
+            await MainActor.run {
+                observeAuthState()
+                fetchNoticeAndConfigureRootViewController()
+                checkForAppUpdate()
+            }
+        }
+    }
+    
     // MARK: - RootViewController & Update
 
     private func observeAuthState() {

--- a/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
@@ -29,7 +29,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.makeKeyAndVisible()
         
         Task {
-            let ok = await AuthService.shared.checkAndRefreshTokenIfNeeded()
+            _ = await AuthService.shared.checkAndRefreshTokenIfNeeded()
             // relay.accept(true/false) 가 이미 호출된 뒤에 구독 시작
             await MainActor.run {
                 self.observeAuthState()

--- a/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
@@ -10,9 +10,11 @@ import UIKit
 import Intents
 
 import KakaoSDKAuth
+import RxSwift
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
+    private let disposeBag = DisposeBag()
 
     // MARK: - UIWindowSceneDelegate Methods
 
@@ -25,7 +27,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let splashVC = SplashViewController()
         window?.rootViewController = splashVC
         window?.makeKeyAndVisible()
-
+        
+        observeAuthState()
         fetchNoticeAndConfigureRootViewController()
         checkForAppUpdate()
     }
@@ -136,6 +139,21 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     // MARK: - RootViewController & Update
 
+    private func observeAuthState() {
+        AuthService.shared.isAuthenticated
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] isAuth in
+                guard let self = self else { return }
+                if isAuth {
+                    self.window?.rootViewController = HomeViewController()
+                } else {
+                    let loginVC = LoginViewController()
+                    self.window?.rootViewController = UINavigationController(rootViewController: loginVC)
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+    
     private func fetchNoticeAndConfigureRootViewController() {
         FirebaseRemoteConfig.shared.noticeCheck { [weak self] result in
             DispatchQueue.main.async {

--- a/EATSSU/App/Sources/Utility/Base/BaseViewController.swift
+++ b/EATSSU/App/Sources/Utility/Base/BaseViewController.swift
@@ -132,15 +132,20 @@ class BaseViewController: UIViewController {
         navigationController?.navigationBar.topItem?.backBarButtonItem = backButton
     }
     
+    /// AuthService의 logoutMessage를 구독하여 로그아웃 메시지를 저장하는 함수
+    /// - 로그인 상태가 해제될 때 전달되는 메시지를 받아서 toastMessage에 저장
+    /// - 이후 viewDidAppear에서 showToastMessageIfNeeded()로 직접 표시됨
     private func observeLogoutMessage() {
         AuthService.shared.logoutMessage
             .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] message in
-                self?.toastMessage = message 
+                self?.toastMessage = message
             })
             .disposed(by: disposeBag)
     }
-    
+
+    /// toastMessage가 존재할 경우 화면에 토스트로 표시하고, 내부 상태를 초기화하는 함수
+    /// - 로그인 만료 시 메시지를 한 번만 표시하도록 동작
     func showToastMessageIfNeeded() {
         guard let message = toastMessage else { return }
         view.showToast(message: message)

--- a/EATSSU/App/Sources/Utility/Base/BaseViewController.swift
+++ b/EATSSU/App/Sources/Utility/Base/BaseViewController.swift
@@ -13,6 +13,8 @@ import EATSSUDesign
 
 import Moya
 import SnapKit
+import RxSwift
+import RxRelay
 
 /// EATSSU 앱에서 Controller로 사용하는 BaseViewController 클래스입니다.
 ///
@@ -27,6 +29,8 @@ import SnapKit
 class BaseViewController: UIViewController {
     // MARK: - Properties
 
+    var toastMessage: String?
+    private let disposeBag = DisposeBag()
     private(set) lazy var className: String = type(of: self).description().components(separatedBy: ".").last ?? ""
 
     // MARK: - Initialize
@@ -52,6 +56,7 @@ class BaseViewController: UIViewController {
         setLayout()
         setButtonEvent()
         setCustomNavigationBar()
+        observeLogoutMessage()
         view.backgroundColor = .systemBackground
     }
 
@@ -125,5 +130,20 @@ class BaseViewController: UIViewController {
         let backButton = UIBarButtonItem()
         backButton.tintColor = EATSSUDesignAsset.Color.GrayScale.gray500.color
         navigationController?.navigationBar.topItem?.backBarButtonItem = backButton
+    }
+    
+    private func observeLogoutMessage() {
+        AuthService.shared.logoutMessage
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] message in
+                self?.toastMessage = message 
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    func showToastMessageIfNeeded() {
+        guard let message = toastMessage else { return }
+        view.showToast(message: message)
+        toastMessage = nil
     }
 }

--- a/EATSSU/Project.swift
+++ b/EATSSU/Project.swift
@@ -93,6 +93,7 @@ let project = Project(
                 .external(name: "GoogleAppMeasurement"),
                 .external(name: "Realm"),
                 .external(name: "RealmSwift"),
+                .external(name: "RxRelay"),
                 .external(name: "FirebaseCrashlytics"),
                 .external(name: "FirebaseAnalytics"),
                 .external(name: "FirebaseRemoteConfig"),
@@ -128,6 +129,7 @@ let project = Project(
                 .external(name: "GoogleAppMeasurement"),
                 .external(name: "Realm"),
                 .external(name: "RealmSwift"),
+                .external(name: "RxRelay"),
                 .external(name: "FirebaseCrashlytics"),
                 .external(name: "FirebaseAnalytics"),
                 .external(name: "FirebaseRemoteConfig"),
@@ -135,7 +137,6 @@ let project = Project(
                 .external(name: "KakaoSDKUser"),
                 .external(name: "KakaoSDKCommon"),
                 .external(name: "KakaoSDKTalk"),
-
                 // EATSSU 내장 라이브러리
                 .project(target: "EATSSUDesign", path: .relativeToRoot("../EATSSUDesign"), condition: .none),
             ],

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -33,6 +33,8 @@ import PackageDescription
 
             // RxSwift
             "RxSwift": .framework,
+            "RxRelay": .framework,
+            
         ]
     )
 #endif


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #302

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 변경 사항이 많아서 파일 이름 위주로 설명 드리겠습니다.

- **인증 로직 통합 및 AuthService 중심 구조 도입**
기존에 각 `ViewController` 또는 네트워크 요청 전 분산되어 있던 토큰 검증, 재발급, 로그아웃 처리 등을 `AuthService`에 통합.
`AuthService.shared.checkAndRefreshTokenIfNeeded()` 호출 방식으로 통일.
인증 상태를 Rx 기반 상태로 관리하도록 설계.
- **화면 전환 흐름 정비 (루트 변경 / 자동 로그아웃 등)**
SceneDelegate 또는 AppDelegate에서 AuthService의 인증 상태를 구독하여 자동 전환 처리.
accessToken, refreshToken 만료 시 루트 뷰 전환을 통해 로그인 화면으로 안전하게 복귀하도록 개선.
- **ViewController 인증 체크 도입**
다음 `ViewController`들에서 `AuthService` 기반의 유효성 체크 로직 추가:
`HomeViewController`, `MyPageViewController`, `MyReviewViewController`, `UserWithdrawViewController`, `ReviewViewController`, `SetRateViewController`, `LoginViewController`, `SetNickNameViewController`
- **기존 BaseViewController, SceneDelegate 등 구조 정비**
BaseViewController에 각 vc에서 쓰이는 toast 메시지 설정
SceneDelegate, AppDelegate에서 초기 진입점 및 상태 감지를 분기
- **TokenManager, TokenRefresher 리팩토링**
토큰 갱신 시 재요청 흐름 정비.
`Alamofire RequestInterceptor` 및 `Moya Plugin`이 `AuthService`와 연동되도록 개선.
refresh 실패 시 로그아웃 처리 자동화.

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 다만,, 이번 `AuthService` 도입과 함께 refresh token 만료 시 자동 로그아웃 처리가 적용되었습니다.
이는 refresh token이 만료된 상황에서 별도 흐름으로 분리해 처리하기에는 구조상 복잡도가 높아,
우선은 자동 로그아웃 방식으로 구현해봤습니다!