### PR TITLE
[#324] 알림 권한 허용 안 함 시, 알림 설정 화면으로 바로 이동

### DIFF
--- a/EATSSU/App/Sources/Notification/NotificationManager.swift
+++ b/EATSSU/App/Sources/Notification/NotificationManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import UserNotifications
+import UIKit
 
 class NotificationManager {
     // MARK: - Properties
@@ -67,21 +68,84 @@ class NotificationManager {
     }
 
     /// 앱 실행 시 알림 발송 권한을 요청하는 팝업 호출 메소드
-    func requestNotificationPermission(completion: @escaping (_ granted: Bool) -> Void) {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) {
-            granted, _ in
-            completion(granted)
-        }
+    func requestNotificationPermission() async throws -> Bool {
+        return try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
     }
 
     /// OS 단계에서 알림 수신 설정을 확인하는 메소드
-    func checkNotificationSetting(completion: @escaping (_ setting: UNNotificationSettings) -> Void) {
-        // 현재 UNUserNotificationCenter 인스턴스 가져오기
-        let notificationCenter = UNUserNotificationCenter.current()
+    func checkNotificationSetting() async -> UNNotificationSettings {
+        return await UNUserNotificationCenter.current().notificationSettings()
+    }
+    
+    /// OS 알림 권한이 거부되었을 때 설정 앱으로 이동
+    func openAppSettings() {
+        if let appSettings = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(appSettings)
+        }
+    }
 
-        // 알림 설정을 비동기적으로 확인
-        notificationCenter.getNotificationSettings { settings in
-            completion(settings)
+    /// 알림 권한 상태에 따라 적절한 액션을 수행하고 결과를 반환
+    func handleNotificationToggle(currentState: Bool) async throws -> Bool {
+        let settings = await checkNotificationSetting()
+        
+        switch settings.authorizationStatus {
+        case .denied:
+            throw NotificationError.permissionDenied
+            
+        case .authorized, .provisional, .ephemeral:
+            let newState = !currentState
+            
+            if newState {
+                scheduleWeekday11AMNotification()
+            } else {
+                cancelWeekday11AMNotification()
+            }
+            
+            return newState
+            
+        case .notDetermined:
+            let granted = try await requestNotificationPermission()
+            
+            if granted {
+                scheduleWeekday11AMNotification()
+                return true
+            } else {
+                throw NotificationError.permissionDenied
+            }
+            
+        @unknown default:
+            throw NotificationError.unknown
+        }
+    }
+    
+    /// OS 알림 설정 화면으로 이동
+    func openNotificationSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url)
+        }
+    }
+
+    // MARK: - Error Types
+    enum NotificationError: Error {
+        case permissionDenied
+        case unknown
+        
+        var message: String {
+            switch self {
+            case .permissionDenied:
+                return "알림 권한 필요"
+            case .unknown:
+                return "알 수 없는 오류"
+            }
+        }
+        
+        var description: String {
+            switch self {
+            case .permissionDenied:
+                return "알림을 받으려면 설정에서 알림 권한을 허용해주세요."
+            case .unknown:
+                return "다시 시도해주세요."
+            }
         }
     }
 }

--- a/EATSSU/App/Sources/Notification/NotificationManager.swift
+++ b/EATSSU/App/Sources/Notification/NotificationManager.swift
@@ -76,13 +76,6 @@ class NotificationManager {
     func checkNotificationSetting() async -> UNNotificationSettings {
         return await UNUserNotificationCenter.current().notificationSettings()
     }
-    
-    /// OS 알림 권한이 거부되었을 때 설정 앱으로 이동
-    func openAppSettings() {
-        if let appSettings = URL(string: UIApplication.openSettingsURLString) {
-            UIApplication.shared.open(appSettings)
-        }
-    }
 
     /// 알림 권한 상태에 따라 적절한 액션을 수행하고 결과를 반환
     func handleNotificationToggle(currentState: Bool) async throws -> Bool {

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -135,7 +135,6 @@ extension MyPageViewController: UITableViewDataSource {
     func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
         myPageTableLabelList.count
     }
-
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.row == MyPageLabels.NotificationSetting.rawValue {
             let cell = tableView
@@ -143,22 +142,22 @@ extension MyPageViewController: UITableViewDataSource {
                     withIdentifier: NotificationSettingTableViewCell.identifier,
                     for: indexPath
                 ) as! NotificationSettingTableViewCell
-
-            NotificationManager.shared.checkNotificationSetting { setting in
-                switch setting.authorizationStatus {
-                case .authorized, .notDetermined, .provisional, .ephemeral:
-                    DispatchQueue.main.async {
+            
+            // Task로 비동기 작업 처리
+            _Concurrency.Task {
+                let settings = await NotificationManager.shared.checkNotificationSetting()
+                
+                await MainActor.run {
+                    switch settings.authorizationStatus {
+                    case .authorized, .notDetermined, .provisional, .ephemeral:
                         cell.toggleSwitch.setOn(self.switchState, animated: true)
-                    }
-                case .denied:
-                    DispatchQueue.main.async {
+                    case .denied:
                         cell.toggleSwitch.setOn(false, animated: true)
+                    @unknown default:
+                        fatalError()
                     }
-                @unknown default:
-                    fatalError()
                 }
             }
-
             return cell
         } else {
             let cell = tableView
@@ -166,7 +165,7 @@ extension MyPageViewController: UITableViewDataSource {
                     withIdentifier: MyPageTableDefaultCell.identifier,
                     for: indexPath
                 ) as! MyPageTableDefaultCell
-
+            
             let title = myPageTableLabelList[indexPath.row].titleLabel
             cell.serviceLabel.text = title
             return cell
@@ -187,42 +186,7 @@ extension MyPageViewController: UITableViewDelegate {
         switch indexPath.row {
         // "푸시 알림 설정" 스위치 토글
         case MyPageLabels.NotificationSetting.rawValue:
-            NotificationManager.shared.checkNotificationSetting { setting in
-                switch setting.authorizationStatus {
-                case .denied:
-                    DispatchQueue.main.async {
-                        self.view.showToast(message: TextLiteral.MyPage.authorizeNotificationSettingMessage)
-                    }
-                default:
-                    DispatchQueue.main.async {
-                        guard let cell = tableView.cellForRow(at: indexPath) as? NotificationSettingTableViewCell else { return }
-                        // 현재 스위치 상태를 반전
-                        let newSwitchState = !self.switchState
-                        cell.toggleSwitch.setOn(newSwitchState, animated: true)
-
-                        // 스위치 상태를 업데이트
-                        self.switchState = newSwitchState
-
-                        let currentDate = Date()
-                        let dateFormatter = DateFormatter()
-                        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm"
-                        let formattedDate = dateFormatter.string(from: currentDate)
-
-                        if self.switchState {
-                            print("푸시 알림을 발송합니다.")
-                            NotificationManager.shared.scheduleWeekday11AMNotification()
-                            self.view.showToast(message: "EAT-SSU 알림 수신을 동의하였습니다.\n(\(formattedDate))")
-                        } else {
-                            print("푸시 알림을 발송하지 않습니다.")
-                            NotificationManager.shared.cancelWeekday11AMNotification()
-                            self.view.showToast(message: "EAT-SSU 알림 수신을 거절하였습니다.\n(\(formattedDate))")
-                        }
-
-                        // UserDefaults에 상태 저장
-                        self.saveSwitchStateToUserDefaults()
-                    }
-                }
-            }
+            handleNotificationSettingToggle(at: indexPath)
             
         // "내 정보" 스크린으로 이동
         case MyPageLabels.MyInfo.rawValue:
@@ -277,5 +241,70 @@ extension MyPageViewController: UITableViewDelegate {
         default:
             return
         }
+    }
+    
+    /// 알림 설정 토글 처리
+    private func handleNotificationSettingToggle(at indexPath: IndexPath) {
+        _Concurrency.Task {
+            do {
+                let newState = try await NotificationManager.shared.handleNotificationToggle(currentState: switchState)
+                
+                // 메인 스레드에서 UI 업데이트
+                await MainActor.run {
+                    // 스위치 상태 업데이트
+                    self.switchState = newState
+                    self.saveSwitchStateToUserDefaults()
+                    
+                    // UI 업데이트
+                    if let cell = self.mypageView.myPageTableView.cellForRow(at: indexPath) as? NotificationSettingTableViewCell {
+                        cell.toggleSwitch.setOn(newState, animated: true)
+                    }
+                    
+                    // 토스트 메시지
+                    let dateFormatter = DateFormatter()
+                    dateFormatter.dateFormat = "yyyy-MM-dd HH:mm"
+                    let formattedDate = dateFormatter.string(from: Date())
+                    
+                    let message = newState
+                        ? "EAT-SSU 알림 수신을 동의하였습니다.\n(\(formattedDate))"
+                        : "EAT-SSU 알림 수신을 거절하였습니다.\n(\(formattedDate))"
+                    
+                    self.view.showToast(message: message)
+                }
+                
+            } catch let error as NotificationManager.NotificationError {
+                await MainActor.run {
+                    if case .permissionDenied = error {
+                        self.showNotificationPermissionAlert()
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    self.showNotificationPermissionAlert()
+                }
+            }
+        }
+    }
+    
+    /// 알림 권한 설정 Alert 표시
+    private func showNotificationPermissionAlert() {
+        let error = NotificationManager.NotificationError.permissionDenied
+        
+        let alert = UIAlertController(
+            title: error.message,
+            message: error.description,
+            preferredStyle: .alert
+        )
+        
+        let settingsAction = UIAlertAction(title: "설정으로 이동", style: .default) { _ in
+            NotificationManager.shared.openNotificationSettings() 
+        }
+        
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        
+        alert.addAction(settingsAction)
+        alert.addAction(cancelAction)
+        
+        present(alert, animated: true)
     }
 }

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -274,13 +274,12 @@ extension MyPageViewController: UITableViewDelegate {
                 
             } catch let error as NotificationManager.NotificationError {
                 await MainActor.run {
-                    if case .permissionDenied = error {
+                    switch error {
+                    case .permissionDenied:
                         self.showNotificationPermissionAlert()
+                    case .unknown:
+                        self.view.showToast(message: "알림 설정 중 오류가 발생했습니다.")
                     }
-                }
-            } catch {
-                await MainActor.run {
-                    self.showNotificationPermissionAlert()
                 }
             }
         }

--- a/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
@@ -106,15 +106,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     private func setupNotificationPermissions() {
         NotificationManager.shared.requestNotificationPermission { granted in
             let userSettingKey = TextLiteral.MyPage.pushNotificationUserSettingKey
+            
+            let hasExistingSetting = UserDefaults.standard.object(forKey: userSettingKey) != nil
             let isAppPermissionGranted = UserDefaults.standard.bool(forKey: userSettingKey)
 
             if granted {
-                if isAppPermissionGranted {
+                if !hasExistingSetting || isAppPermissionGranted {
                     NotificationManager.shared.scheduleWeekday11AMNotification()
                     UserDefaults.standard.set(true, forKey: userSettingKey)
                 } else {
                     NotificationManager.shared.cancelWeekday11AMNotification()
-                    UserDefaults.standard.set(false, forKey: userSettingKey)
                 }
             } else {
                 NotificationManager.shared.cancelWeekday11AMNotification()

--- a/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
@@ -104,22 +104,31 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     
     /// 푸시 알림 권한을 요청하고 설정을 처리합니다.
     private func setupNotificationPermissions() {
-        NotificationManager.shared.requestNotificationPermission { granted in
-            let userSettingKey = TextLiteral.MyPage.pushNotificationUserSettingKey
-            
-            let hasExistingSetting = UserDefaults.standard.object(forKey: userSettingKey) != nil
-            let isAppPermissionGranted = UserDefaults.standard.bool(forKey: userSettingKey)
+        _Concurrency.Task {
+            do {
+                let granted = try await NotificationManager.shared.requestNotificationPermission()
+                
+                let userSettingKey = TextLiteral.MyPage.pushNotificationUserSettingKey
+                
+                let hasExistingSetting = UserDefaults.standard.object(forKey: userSettingKey) != nil
+                let isAppPermissionGranted = UserDefaults.standard.bool(forKey: userSettingKey)
 
-            if granted {
-                if !hasExistingSetting || isAppPermissionGranted {
-                    NotificationManager.shared.scheduleWeekday11AMNotification()
-                    UserDefaults.standard.set(true, forKey: userSettingKey)
+                if granted {
+                    if !hasExistingSetting || isAppPermissionGranted {
+                        NotificationManager.shared.scheduleWeekday11AMNotification()
+                        UserDefaults.standard.set(true, forKey: userSettingKey)
+                    } else {
+                        NotificationManager.shared.cancelWeekday11AMNotification()
+                    }
                 } else {
                     NotificationManager.shared.cancelWeekday11AMNotification()
+                    UserDefaults.standard.set(false, forKey: userSettingKey)
                 }
-            } else {
+            } catch {
+                // 권한 요청 실패 시 처리
+                print("알림 권한 요청 실패: \(error)")
                 NotificationManager.shared.cancelWeekday11AMNotification()
-                UserDefaults.standard.set(false, forKey: userSettingKey)
+                UserDefaults.standard.set(false, forKey: TextLiteral.MyPage.pushNotificationUserSettingKey)
             }
         }
     }

--- a/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
@@ -105,10 +105,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     /// 푸시 알림 권한을 요청하고 설정을 처리합니다.
     private func setupNotificationPermissions() {
         _Concurrency.Task {
+            let userSettingKey = TextLiteral.MyPage.pushNotificationUserSettingKey
             do {
                 let granted = try await NotificationManager.shared.requestNotificationPermission()
-                
-                let userSettingKey = TextLiteral.MyPage.pushNotificationUserSettingKey
                 
                 let hasExistingSetting = UserDefaults.standard.object(forKey: userSettingKey) != nil
                 let isAppPermissionGranted = UserDefaults.standard.bool(forKey: userSettingKey)
@@ -125,10 +124,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                     UserDefaults.standard.set(false, forKey: userSettingKey)
                 }
             } catch {
-                // 권한 요청 실패 시 처리
                 print("알림 권한 요청 실패: \(error)")
                 NotificationManager.shared.cancelWeekday11AMNotification()
-                UserDefaults.standard.set(false, forKey: TextLiteral.MyPage.pushNotificationUserSettingKey)
+                UserDefaults.standard.set(false, forKey: userSettingKey) 
             }
         }
     }


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #324 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 알림 권한 허용 안 함 시, 알림 설정 화면으로 바로 이동했습니다.
- 기존 비동기 코드를 Concurrency를 통해 리팩토링 했습니다.
- VC 파일의 로직을 매니저 파일 이동시켰습니다.

https://github.com/user-attachments/assets/a49edceb-22a0-445c-82bd-aed991cea7ff



### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
