### PR TITLE
[#351] 마이페이지에 리뷰 없을 때 빈 화면이 뜨는 버그 수정

### DIFF
--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
@@ -119,7 +119,14 @@ final class MyReviewViewController: BaseViewController {
     }
 }
 
-extension MyReviewViewController: UITableViewDelegate {}
+extension MyReviewViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        if reviewList.isEmpty {
+            return tableView.bounds.height - 150
+        }
+        return UITableView.automaticDimension
+    }
+}
 
 extension MyReviewViewController: UITableViewDataSource {
     func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
@@ -28,20 +28,12 @@ final class MyReviewViewController: BaseViewController {
         super.init(nibName: nil, bundle: nil)
     }
 
-    private lazy var noMyReviewImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = ImageLiteral.noMyReview
-        imageView.isHidden = true
-        return imageView
-    }()
-
     // MARK: - Life Cycles
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         setDelegate()
-        checkReviewCount()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -64,21 +56,18 @@ final class MyReviewViewController: BaseViewController {
     }
 
     override func configureUI() {
-        view.addSubviews(myReviewView, noMyReviewImageView)
+        view.addSubviews(myReviewView)
     }
 
     override func setLayout() {
         myReviewView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
-
-        noMyReviewImageView.snp.makeConstraints {
-            $0.center.equalToSuperview()
-        }
     }
 
     private func setDelegate() {
         myReviewView.myReviewTableView.register(ReviewTableCell.self, forCellReuseIdentifier: ReviewTableCell.identifier)
+        myReviewView.myReviewTableView.register(ReviewEmptyViewCell.self, forCellReuseIdentifier: ReviewEmptyViewCell.identifier)
         myReviewView.myReviewTableView.delegate = self
         myReviewView.myReviewTableView.dataSource = self
     }
@@ -115,16 +104,6 @@ final class MyReviewViewController: BaseViewController {
         alert.addAction(cancelAction)
         present(alert, animated: true, completion: nil)
     }
-
-    func checkReviewCount() {
-        if reviewList.count == 0 {
-            myReviewView.myReviewTableView.isHidden = true
-            noMyReviewImageView.isHidden = false
-        } else {
-            myReviewView.myReviewTableView.isHidden = false
-            noMyReviewImageView.isHidden = true
-        }
-    }
     
     private func navigateToLogin() {
         let loginVC = LoginViewController()
@@ -144,10 +123,18 @@ extension MyReviewViewController: UITableViewDelegate {}
 
 extension MyReviewViewController: UITableViewDataSource {
     func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
-        reviewList.count
+        return reviewList.isEmpty ? 1 : reviewList.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        if reviewList.isEmpty {
+            let cell = tableView.dequeueReusableCell(withIdentifier: ReviewEmptyViewCell.identifier, for: indexPath) as? ReviewEmptyViewCell ?? ReviewEmptyViewCell()
+            cell.configureForMyReview()
+            cell.selectionStyle = .none
+            return cell
+        }
+        
         let cell = tableView.dequeueReusableCell(withIdentifier: ReviewTableCell.identifier, for: indexPath) as? ReviewTableCell ?? ReviewTableCell()
         cell.myPageDataBind(response: reviewList[indexPath.row], nickname: nickname)
         cell.handler = { [weak self] in
@@ -175,7 +162,6 @@ extension MyReviewViewController {
             switch result {
             case .success(let response):
                 self.reviewList = response.dataList
-                self.checkReviewCount()
                 self.myReviewView.myReviewTableView.reloadData()
                 
             case .failure(let error):

--- a/EATSSU/App/Sources/Presentation/Review/View/SeeReview/ReviewEmptyViewCell.swift
+++ b/EATSSU/App/Sources/Presentation/Review/View/SeeReview/ReviewEmptyViewCell.swift
@@ -28,7 +28,7 @@ final class ReviewEmptyViewCell: UITableViewCell {
     private lazy var mainLabel: UILabel = {
         let label = UILabel()
         label.text = "아직 작성된 리뷰가 없어요!"
-        label.font = EATSSUDesignFontFamily.Pretendard.medium.font(size: 16)
+        label.font = EATSSUDesignFontFamily.Pretendard.semiBold.font(size: 16)
         label.textColor = EATSSUDesignAsset.Color.GrayScale.gray600.color
         label.textAlignment = .center
         return label

--- a/EATSSU/App/Sources/Presentation/Review/View/SeeReview/ReviewEmptyViewCell.swift
+++ b/EATSSU/App/Sources/Presentation/Review/View/SeeReview/ReviewEmptyViewCell.swift
@@ -83,4 +83,9 @@ final class ReviewEmptyViewCell: UITableViewCell {
             subLabel.text = "로그인 후 리뷰를 확인하세요"
         }
     }
+    
+    func configureForMyReview() {
+        mainLabel.text = "아직 작성한 리뷰가 없어요"
+        subLabel.text = "첫 리뷰를 남겨 주세요!"
+    }
 }


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #351 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

**UI 및 빈 상태(Empty State) 처리 리팩토링**

- UI 로직 단순화: MyReviewViewController에서 기존에 별도의 이미지 뷰(noMyReviewImageView)로 처리하던 빈 상태 로직을 제거하고, 테이블 뷰 셀(ReviewEmptyViewCell)을 사용하는 방식으로 변경했습니다. 이를 통해 유지보수성을 높였습니다.

- 테이블 뷰 설정 업데이트: 리뷰가 없을 때 전용 셀(Empty Cell)이 표시되도록 Delegate와 Data Source 메서드를 수정하고, 해당 상태일 때의 셀 높이 설정 로직을 추가했습니다.

**ReviewEmptyViewCell 개선**

- 폰트 변경: 메인 라벨의 폰트를 semiBold로 변경하여 텍스트를 더 강조했습니다.

- 설정 메서드 추가: configureForMyReview() 메서드를 추가하여, '내 리뷰'가 없을 때 사용자에게 보여줄 문구를 커스텀할 수 있도록 기능을 확장했습니다.


> 좌 에어16, 우 SE 입니다.

<img width="250" alt="Simulator Screenshot - iPhone Air - 2025-11-17 at 16 36 45" src="https://github.com/user-attachments/assets/380dfc7f-d15a-46ba-a110-3dd9bde6a790" />
<img width="250" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2025-11-17 at 16 36 54" src="https://github.com/user-attachments/assets/01f9d2a2-d392-49ce-9296-d36a491cc64e" />


### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
