### PR TITLE
[#352] 위젯 ESTimelineProvider 로직 변경 및 UI 업데이트 

### DIFF
--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
@@ -119,7 +119,14 @@ final class MyReviewViewController: BaseViewController {
     }
 }
 
-extension MyReviewViewController: UITableViewDelegate {}
+extension MyReviewViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        if reviewList.isEmpty {
+            return tableView.bounds.height - 150
+        }
+        return UITableView.automaticDimension
+    }
+}
 
 extension MyReviewViewController: UITableViewDataSource {
     func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
@@ -28,20 +28,12 @@ final class MyReviewViewController: BaseViewController {
         super.init(nibName: nil, bundle: nil)
     }
 
-    private lazy var noMyReviewImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = ImageLiteral.noMyReview
-        imageView.isHidden = true
-        return imageView
-    }()
-
     // MARK: - Life Cycles
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         setDelegate()
-        checkReviewCount()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -64,21 +56,18 @@ final class MyReviewViewController: BaseViewController {
     }
 
     override func configureUI() {
-        view.addSubviews(myReviewView, noMyReviewImageView)
+        view.addSubviews(myReviewView)
     }
 
     override func setLayout() {
         myReviewView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
-
-        noMyReviewImageView.snp.makeConstraints {
-            $0.center.equalToSuperview()
-        }
     }
 
     private func setDelegate() {
         myReviewView.myReviewTableView.register(ReviewTableCell.self, forCellReuseIdentifier: ReviewTableCell.identifier)
+        myReviewView.myReviewTableView.register(ReviewEmptyViewCell.self, forCellReuseIdentifier: ReviewEmptyViewCell.identifier)
         myReviewView.myReviewTableView.delegate = self
         myReviewView.myReviewTableView.dataSource = self
     }
@@ -115,16 +104,6 @@ final class MyReviewViewController: BaseViewController {
         alert.addAction(cancelAction)
         present(alert, animated: true, completion: nil)
     }
-
-    func checkReviewCount() {
-        if reviewList.count == 0 {
-            myReviewView.myReviewTableView.isHidden = true
-            noMyReviewImageView.isHidden = false
-        } else {
-            myReviewView.myReviewTableView.isHidden = false
-            noMyReviewImageView.isHidden = true
-        }
-    }
     
     private func navigateToLogin() {
         let loginVC = LoginViewController()
@@ -144,10 +123,18 @@ extension MyReviewViewController: UITableViewDelegate {}
 
 extension MyReviewViewController: UITableViewDataSource {
     func tableView(_: UITableView, numberOfRowsInSection _: Int) -> Int {
-        reviewList.count
+        return reviewList.isEmpty ? 1 : reviewList.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        if reviewList.isEmpty {
+            let cell = tableView.dequeueReusableCell(withIdentifier: ReviewEmptyViewCell.identifier, for: indexPath) as? ReviewEmptyViewCell ?? ReviewEmptyViewCell()
+            cell.configureForMyReview()
+            cell.selectionStyle = .none
+            return cell
+        }
+        
         let cell = tableView.dequeueReusableCell(withIdentifier: ReviewTableCell.identifier, for: indexPath) as? ReviewTableCell ?? ReviewTableCell()
         cell.myPageDataBind(response: reviewList[indexPath.row], nickname: nickname)
         cell.handler = { [weak self] in
@@ -175,7 +162,6 @@ extension MyReviewViewController {
             switch result {
             case .success(let response):
                 self.reviewList = response.dataList
-                self.checkReviewCount()
                 self.myReviewView.myReviewTableView.reloadData()
                 
             case .failure(let error):

--- a/EATSSU/App/Sources/Presentation/Review/View/SeeReview/ReviewEmptyViewCell.swift
+++ b/EATSSU/App/Sources/Presentation/Review/View/SeeReview/ReviewEmptyViewCell.swift
@@ -28,7 +28,7 @@ final class ReviewEmptyViewCell: UITableViewCell {
     private lazy var mainLabel: UILabel = {
         let label = UILabel()
         label.text = "아직 작성된 리뷰가 없어요!"
-        label.font = EATSSUDesignFontFamily.Pretendard.medium.font(size: 16)
+        label.font = EATSSUDesignFontFamily.Pretendard.semiBold.font(size: 16)
         label.textColor = EATSSUDesignAsset.Color.GrayScale.gray600.color
         label.textAlignment = .center
         return label

--- a/EATSSU/App/Sources/Presentation/Review/View/SeeReview/ReviewEmptyViewCell.swift
+++ b/EATSSU/App/Sources/Presentation/Review/View/SeeReview/ReviewEmptyViewCell.swift
@@ -83,4 +83,9 @@ final class ReviewEmptyViewCell: UITableViewCell {
             subLabel.text = "로그인 후 리뷰를 확인하세요"
         }
     }
+    
+    func configureForMyReview() {
+        mainLabel.text = "아직 작성한 리뷰가 없어요"
+        subLabel.text = "첫 리뷰를 남겨 주세요!"
+    }
 }

--- a/EATSSU/Project.swift
+++ b/EATSSU/Project.swift
@@ -216,8 +216,7 @@ let project = Project(
             entitlements: "App/Entitlements/EatSSU-iOS-Dev.entitlements",
             dependencies: [
                 .external(name: "Moya"),
-                .external(name: "RxSwift"),
-                .external(name: "RxMoya"),
+                .external(name: "CombineMoya"),
                 .external(name: "FirebaseAnalytics"),
                 .external(name: "GoogleAppMeasurement"),
 
@@ -257,8 +256,7 @@ let project = Project(
             entitlements: "App/Entitlements/EatSSU-iOS-Prod.entitlements",
             dependencies: [
                 .external(name: "Moya"),
-                .external(name: "RxSwift"),
-                .external(name: "RxMoya"),
+                .external(name: "CombineMoya"),
                 .external(name: "FirebaseAnalytics"),
                 .external(name: "GoogleAppMeasurement"),
 

--- a/EATSSU/Widget/Sources/Data/Timeline/ESTimelineProvider.swift
+++ b/EATSSU/Widget/Sources/Data/Timeline/ESTimelineProvider.swift
@@ -49,7 +49,6 @@ struct ESTimelineProvider: AppIntentTimelineProvider {
         if !context.isPreview {
             checkForWidgetEvents(configuration: configuration)
         }
-        let updateInterval: TimeInterval = 60 * 60 // 1시간마다 업데이트
         let currentDate = Date()
         let formattedDate = formatDate(currentDate) // 현재 날짜를 문자열로 변환
         let restaurant = configuration.selectedRestaurant.rawValue // 선택된 식당의 rawValue
@@ -59,16 +58,9 @@ struct ESTimelineProvider: AppIntentTimelineProvider {
             print("Requesting menu for date: \(formattedDate), restaurant: \(restaurant), time: \(timeSlot)")
         #endif
 
-        // 초기 기본 엔트리 생성 (네트워크 요청 이전 기본값)
-        let initialEntry = ESEntry(
-            date: currentDate,
-            restaurantName: configuration.selectedRestaurant.displayName,
-            timeSlot: timeSlot
-        )
-        var timeline = Timeline(entries: [initialEntry], policy: .after(currentDate.addingTimeInterval(updateInterval)))
-
         let provider = MoyaProvider<HomeRouter>() // Moya를 이용한 네트워크 요청 객체 생성
-
+        var timeline: Timeline<ESEntry>
+        
         do {
             // 네트워크 요청을 통해 메뉴 데이터를 가져옴
             let menus = try await fetchMenu(provider: provider, date: formattedDate, restaurant: restaurant, time: timeSlot)
@@ -80,7 +72,8 @@ struct ESTimelineProvider: AppIntentTimelineProvider {
             )
 
             // 새로운 데이터로 타임라인 업데이트
-            timeline = Timeline(entries: [updatedEntry], policy: .atEnd)
+            let nextUpdate = calculateNextUpdateTime(from: currentDate)
+            timeline = Timeline(entries: [updatedEntry], policy: .after(nextUpdate))
         } catch {
             #if DEBUG
                 print("Error: \(error.localizedDescription)") // 네트워크 요청 실패 시 오류 출력
@@ -93,8 +86,8 @@ struct ESTimelineProvider: AppIntentTimelineProvider {
                 timeSlot: timeSlot,
                 isError: true
             )
-            timeline = Timeline(entries: [errorEntry], policy: .atEnd)
-        }
+            let retryDate = currentDate.addingTimeInterval(300)
+            timeline = Timeline(entries: [errorEntry], policy: .after(retryDate))        }
 
         return timeline
     }
@@ -135,6 +128,25 @@ struct ESTimelineProvider: AppIntentTimelineProvider {
         case 10 ..< 16: return "LUNCH"
         case 16 ..< 24: return "DINNER"
         default: return "CLOSED"
+        }
+    }
+    
+    private func calculateNextUpdateTime(from date: Date) -> Date {
+        let calendar = Calendar.current
+        let hour = calendar.component(.hour, from: date)
+        
+        if hour < 10 {
+            // 현재 아침(0-10시) → 10시에 점심으로 전환
+            return calendar.date(bySettingHour: 10, minute: 0, second: 0, of: date) ?? date
+        } else if hour < 16 {
+            // 현재 점심(10-16시) → 16시에 저녁으로 전환
+            return calendar.date(bySettingHour: 16, minute: 0, second: 0, of: date) ?? date
+        } else {
+            // 현재 저녁(16-24시) → 다음날 0시에 아침으로 전환
+            if let tomorrow = calendar.date(byAdding: .day, value: 1, to: date) {
+                return calendar.startOfDay(for: tomorrow)
+            }
+            return date
         }
     }
 }

--- a/EATSSU/Widget/Sources/Data/Timeline/ESTimelineProvider.swift
+++ b/EATSSU/Widget/Sources/Data/Timeline/ESTimelineProvider.swift
@@ -5,17 +5,16 @@
 //  Created by JIWOONG CHOI on 12/31/24.
 //
 
-import Moya
-import RxMoya
-import RxSwift
+import Combine
 import WidgetKit
+
+import Moya
 
 // 위젯의 타임라인 데이터를 제공하는 프로바이더 구조체
 struct ESTimelineProvider: AppIntentTimelineProvider {
     typealias Intent = SelectRestaurant // 사용자가 선택한 식당 정보를 저장하는 인텐트
     typealias Entry = ESEntry // 위젯에 표시될 데이터 구조체
 
-    private let disposeBag = DisposeBag() // RxSwift의 메모리 관리를 위한 DisposeBag
     private let userDefaults = UserDefaults(suiteName: Bundle.main.infoDictionary?["AppGroupID"] as? String)
     
     // 위젯이 처음 로드될 때 보여줄 기본 데이터
@@ -116,19 +115,9 @@ struct ESTimelineProvider: AppIntentTimelineProvider {
 
     // 서버에서 특정 날짜, 식당, 시간대의 메뉴 정보를 가져오는 함수
     private func fetchMenu(provider: MoyaProvider<HomeRouter>, date: String, restaurant: String, time: String) async throws -> [String] {
-        try await withCheckedThrowingContinuation { continuation in
-            provider.rx.request(.getChangeMenuTableResponse(date: date, restaurant: restaurant, time: time))
-                .map(BaseResponse<[ChangeMenuTableResponse]>.self) // 응답을 모델로 변환
-                .subscribe(onSuccess: { response in
-                    // 서버 응답에서 메뉴 이름만 추출
-                    let menuNames = response.result.flatMap { $0.briefMenus.map(\.name) }
-                    continuation.resume(returning: menuNames)
-                }, onFailure: { error in
-                    print("RxMoya Error: \(error.localizedDescription)")
-                    continuation.resume(throwing: error)
-                })
-                .disposed(by: disposeBag) // DisposeBag을 이용해 메모리 관리
-        }
+        let response = try await provider.request(.getChangeMenuTableResponse(date: date, restaurant: restaurant, time: time))
+        let decoded = try response.map(BaseResponse<[ChangeMenuTableResponse]>.self)
+        return decoded.result.flatMap { $0.briefMenus.map(\.name) }
     }
 
     // Date 객체를 "yyyyMMdd" 형식의 문자열로 변환하는 함수
@@ -146,6 +135,22 @@ struct ESTimelineProvider: AppIntentTimelineProvider {
         case 10 ..< 16: return "LUNCH"
         case 16 ..< 24: return "DINNER"
         default: return "CLOSED"
+        }
+    }
+}
+
+// MARK: - Moya Async Extension
+extension MoyaProvider {
+    func request(_ target: Target) async throws -> Response {
+        try await withCheckedThrowingContinuation { continuation in
+            self.request(target) { result in
+                switch result {
+                case .success(let response):
+                    continuation.resume(returning: response)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
         }
     }
 }

--- a/EATSSU/Widget/Sources/Presentation/Views/ErrorView/MediumErrorView.swift
+++ b/EATSSU/Widget/Sources/Presentation/Views/ErrorView/MediumErrorView.swift
@@ -13,18 +13,16 @@ struct MediumErrorView: View {
     var entry: ESEntry
 
     var body: some View {
-        VStack {
-            Spacer()
-
+        VStack(spacing: 8) {
             HStack {
                 Text(entry.restaurantName)
-                    .font(EATSSUDesignFontFamily.Pretendard.bold.swiftUIFont(size: 10))
+                    .font(EATSSUDesignFontFamily.Pretendard.bold.swiftUIFont(size: 12))
                     .foregroundStyle(.black)
                     .dynamicTypeSize(.xLarge ... .xxxLarge)
 
                 if entry.timeSlot == "MORNING" || entry.timeSlot == "LUNCH" || entry.timeSlot == "DINNER" {
                     Text(entry.timeSlot == "MORNING" ? "조식" : entry.timeSlot == "LUNCH" ? "중식" : "석식")
-                        .font(EATSSUDesignFontFamily.Pretendard.regular.swiftUIFont(size: 8))
+                        .font(EATSSUDesignFontFamily.Pretendard.regular.swiftUIFont(size: 10))
                         .foregroundStyle(.black)
                         .dynamicTypeSize(.xLarge ... .xxxLarge)
                 }
@@ -35,11 +33,14 @@ struct MediumErrorView: View {
                     .resizable()
                     .frame(width: 44, height: 14)
             }
-
-            Spacer()
+            .padding(8)
 
             VStack {
+                Spacer(minLength: 0)
+                
                 Image(asset: EATSSUDesignAsset.Images.networkErrorInfoMediumSign)
+                
+                Spacer(minLength: 0)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(
@@ -47,6 +48,7 @@ struct MediumErrorView: View {
                     .fill(EATSSUDesignAsset.Color.GrayScale.gray100.swiftUIColor)
             )
         }
+        .padding(12)
         .background(Color.white)
     }
 }

--- a/EATSSU/Widget/Sources/Presentation/Views/ErrorView/SmallErrorView.swift
+++ b/EATSSU/Widget/Sources/Presentation/Views/ErrorView/SmallErrorView.swift
@@ -13,7 +13,7 @@ struct SmallErrorView: View {
     var entry: ESEntry
 
     var body: some View {
-        VStack {
+        VStack(spacing: 8) {
             HStack {
                 Text(entry.restaurantName)
                     .font(EATSSUDesignFontFamily.Pretendard.bold.swiftUIFont(size: 10))
@@ -27,17 +27,20 @@ struct SmallErrorView: View {
                         .dynamicTypeSize(.xLarge ... .xxxLarge)
                 }
 
-                Spacer()
+                Spacer(minLength: 4)
 
                 Image(asset: EATSSUDesignAsset.Images.miniLogo)
                     .resizable()
                     .frame(width: 10, height: 10)
             }
-
-            Spacer()
+            .padding(.horizontal, 8)
 
             VStack {
+                Spacer(minLength: 0)
+                
                 Image(asset: EATSSUDesignAsset.Images.networkErrorInfoSmallSign)
+                
+                Spacer(minLength: 0)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(
@@ -45,6 +48,7 @@ struct SmallErrorView: View {
                     .fill(EATSSUDesignAsset.Color.GrayScale.gray100.swiftUIColor)
             )
         }
+        .padding(12)
         .background(Color.white)
     }
 }

--- a/EATSSU/Widget/Sources/Presentation/Views/SuccessView/EmptyMenuView/MediumEmptyMenuView.swift
+++ b/EATSSU/Widget/Sources/Presentation/Views/SuccessView/EmptyMenuView/MediumEmptyMenuView.swift
@@ -13,18 +13,16 @@ struct MediumEmptyMenuView: View {
     var entry: ESEntry
 
     var body: some View {
-        VStack {
-            Spacer()
-
+        VStack(spacing: 8) {
             HStack {
                 Text(entry.restaurantName)
-                    .font(EATSSUDesignFontFamily.Pretendard.bold.swiftUIFont(size: 10))
+                    .font(EATSSUDesignFontFamily.Pretendard.bold.swiftUIFont(size: 12))
                     .foregroundStyle(.black)
                     .dynamicTypeSize(.xLarge ... .xxxLarge)
 
                 if entry.timeSlot == "MORNING" || entry.timeSlot == "LUNCH" || entry.timeSlot == "DINNER" {
                     Text(entry.timeSlot == "MORNING" ? "조식" : entry.timeSlot == "LUNCH" ? "중식" : "석식")
-                        .font(EATSSUDesignFontFamily.Pretendard.regular.swiftUIFont(size: 8))
+                        .font(EATSSUDesignFontFamily.Pretendard.regular.swiftUIFont(size: 10))
                         .foregroundStyle(.black)
                         .dynamicTypeSize(.xLarge ... .xxxLarge)
                 }
@@ -35,11 +33,14 @@ struct MediumEmptyMenuView: View {
                     .resizable()
                     .frame(width: 44, height: 14)
             }
-
-            Spacer()
+            .padding(8)
 
             VStack {
+                Spacer(minLength: 0)
+                
                 Image(asset: EATSSUDesignAsset.Images.noMenuInfoSign)
+                
+                Spacer(minLength: 0)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(
@@ -47,6 +48,7 @@ struct MediumEmptyMenuView: View {
                     .fill(EATSSUDesignAsset.Color.GrayScale.gray100.swiftUIColor)
             )
         }
+        .padding(12)
         .background(Color.white)
     }
 }

--- a/EATSSU/Widget/Sources/Presentation/Views/SuccessView/EmptyMenuView/SmallEmptyMenuView.swift
+++ b/EATSSU/Widget/Sources/Presentation/Views/SuccessView/EmptyMenuView/SmallEmptyMenuView.swift
@@ -13,9 +13,7 @@ struct SmallEmptyMenuView: View {
     var entry: ESEntry
 
     var body: some View {
-        Spacer()
-
-        VStack {
+        VStack(spacing: 8) {
             HStack {
                 Text(entry.restaurantName)
                     .font(EATSSUDesignFontFamily.Pretendard.bold.swiftUIFont(size: 10))
@@ -29,17 +27,20 @@ struct SmallEmptyMenuView: View {
                         .dynamicTypeSize(.xLarge ... .xxxLarge)
                 }
 
-                Spacer()
+                Spacer(minLength: 4)
 
                 Image(asset: EATSSUDesignAsset.Images.miniLogo)
                     .resizable()
                     .frame(width: 10, height: 10)
             }
-
-            Spacer()
+            .padding(.horizontal, 8)
 
             VStack {
+                Spacer(minLength: 0)
+                
                 Image(asset: EATSSUDesignAsset.Images.noMenuInfoSign)
+                
+                Spacer(minLength: 0)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(
@@ -47,8 +48,7 @@ struct SmallEmptyMenuView: View {
                     .fill(EATSSUDesignAsset.Color.GrayScale.gray100.swiftUIColor)
             )
         }
+        .padding(12)
         .background(Color.white)
-
-        Spacer()
     }
 }

--- a/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/MediumNormalView.swift
+++ b/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/MediumNormalView.swift
@@ -36,17 +36,18 @@ struct MediumNormalView: View {
             .padding(8)
 
             VStack {
-                Spacer(minLength: 0)
-
-                Text(entry.menus.joined(separator: " + "))
-                    .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 12))
-                    .foregroundStyle(.black)
-                    .lineLimit(nil)
-                    .multilineTextAlignment(.leading)
-                    .dynamicTypeSize(.xLarge ... .xxxLarge)
-                    .padding(8)
-
-                Spacer(minLength: 0)
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(entry.menus, id: \.self) { menu in
+                        Text(menu)
+                            .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 12))
+                            .foregroundStyle(.black)
+                            .lineLimit(nil)
+                            .multilineTextAlignment(.leading)
+                            .dynamicTypeSize(.xLarge ... .xxxLarge)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(8)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(

--- a/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/MediumNormalView.swift
+++ b/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/MediumNormalView.swift
@@ -13,20 +13,16 @@ struct MediumNormalView: View {
     var entry: ESEntry
 
     var body: some View {
-        Spacer()
-
-        VStack {
-            Spacer()
-
+        VStack(spacing: 8) {
             HStack {
                 Text(entry.restaurantName)
-                    .font(EATSSUDesignFontFamily.Pretendard.bold.swiftUIFont(size: 10))
+                    .font(EATSSUDesignFontFamily.Pretendard.bold.swiftUIFont(size: 12))
                     .foregroundStyle(.black)
                     .dynamicTypeSize(.xLarge ... .xxxLarge)
 
                 if entry.timeSlot == "MORNING" || entry.timeSlot == "LUNCH" || entry.timeSlot == "DINNER" {
                     Text(entry.timeSlot == "MORNING" ? "조식" : entry.timeSlot == "LUNCH" ? "중식" : "석식")
-                        .font(EATSSUDesignFontFamily.Pretendard.regular.swiftUIFont(size: 8))
+                        .font(EATSSUDesignFontFamily.Pretendard.regular.swiftUIFont(size: 10))
                         .foregroundStyle(.black)
                         .dynamicTypeSize(.xLarge ... .xxxLarge)
                 }
@@ -37,22 +33,20 @@ struct MediumNormalView: View {
                     .resizable()
                     .frame(width: 44, height: 14)
             }
-
-            Spacer()
+            .padding(8)
 
             VStack {
-                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], alignment: .leading, spacing: 8) {
-                    ForEach(entry.menus.prefix(10), id: \.self) { menu in
-                        Text(menu)
-                            .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 11))
-                            .foregroundStyle(.black)
-                            .lineLimit(1)
-                            .dynamicTypeSize(.xLarge ... .xxxLarge)
-                    }
-                }
-                .padding(5)
+                Spacer(minLength: 0)
 
-                Spacer()
+                Text(entry.menus.joined(separator: " + "))
+                    .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 12))
+                    .foregroundStyle(.black)
+                    .lineLimit(nil)
+                    .multilineTextAlignment(.leading)
+                    .dynamicTypeSize(.xLarge ... .xxxLarge)
+                    .padding(8)
+
+                Spacer(minLength: 0)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(
@@ -60,8 +54,7 @@ struct MediumNormalView: View {
                     .fill(EATSSUDesignAsset.Color.GrayScale.gray100.swiftUIColor)
             )
         }
+        .padding(12)
         .background(Color.white)
-
-        Spacer()
     }
 }

--- a/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/SmallNormalView.swift
+++ b/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/SmallNormalView.swift
@@ -13,9 +13,7 @@ struct SmallNormalView: View {
     var entry: ESEntry
 
     var body: some View {
-        Spacer()
-
-        VStack {
+        VStack(spacing: 8) {
             HStack {
                 Text(entry.restaurantName)
                     .font(EATSSUDesignFontFamily.Pretendard.bold.swiftUIFont(size: 10))
@@ -29,28 +27,26 @@ struct SmallNormalView: View {
                         .dynamicTypeSize(.xLarge ... .xxxLarge)
                 }
 
-                Spacer()
+                Spacer(minLength: 4)
 
                 Image(asset: EATSSUDesignAsset.Images.miniLogo)
                     .resizable()
                     .frame(width: 10, height: 10)
             }
-
-            Spacer()
+            .padding(8)
 
             VStack {
-                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], alignment: .leading, spacing: 10) {
-                    ForEach(entry.menus.prefix(8), id: \.self) { menu in
-                        Text(menu)
-                            .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 11))
-                            .foregroundStyle(.black)
-                            .lineLimit(1)
-                            .dynamicTypeSize(.xLarge ... .xxxLarge)
-                    }
-                }
-                .padding(5)
+                Spacer(minLength: 0)
 
-                Spacer()
+                Text(entry.menus.joined(separator: " + "))
+                    .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 11))
+                    .foregroundStyle(.black)
+                    .lineLimit(nil)
+                    .multilineTextAlignment(.leading)
+                    .dynamicTypeSize(.xLarge ... .xxxLarge)
+                    .padding(8)
+
+                Spacer(minLength: 0)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(
@@ -58,8 +54,7 @@ struct SmallNormalView: View {
                     .fill(EATSSUDesignAsset.Color.GrayScale.gray100.swiftUIColor)
             )
         }
+        .padding(12)
         .background(Color.white)
-
-        Spacer()
     }
 }

--- a/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/SmallNormalView.swift
+++ b/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/SmallNormalView.swift
@@ -36,17 +36,18 @@ struct SmallNormalView: View {
             .padding(8)
 
             VStack {
-                Spacer(minLength: 0)
-
-                Text(entry.menus.joined(separator: " + "))
-                    .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 11))
-                    .foregroundStyle(.black)
-                    .lineLimit(nil)
-                    .multilineTextAlignment(.leading)
-                    .dynamicTypeSize(.xLarge ... .xxxLarge)
-                    .padding(8)
-
-                Spacer(minLength: 0)
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(entry.menus, id: \.self) { menu in
+                        Text(menu)
+                            .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 11))
+                            .foregroundStyle(.black)
+                            .lineLimit(nil)
+                            .multilineTextAlignment(.leading)
+                            .dynamicTypeSize(.xLarge ... .xxxLarge)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(8)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(

--- a/EATSSU/Widget/Sources/Presentation/Widget/EATSSUWidget.swift
+++ b/EATSSU/Widget/Sources/Presentation/Widget/EATSSUWidget.swift
@@ -31,5 +31,6 @@ struct EATSSUWidget: Widget {
         .configurationDisplayName("EATSSU 위젯")
         .description("확인하고 싶은 식당을 선택하세요.")
         .supportedFamilies([.systemSmall, .systemMedium])
+        .contentMarginsDisabled()
     }
 }

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -53,7 +53,6 @@ let package = Package(
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: "11.1.0"),
         .package(url: "https://github.com/google/GoogleAppMeasurement", from: "11.1.0"),
         .package(url: "https://github.com/realm/realm-swift", from: "20.0.0"),
-        .package(url: "https://github.com/ReactiveX/RxSwift", from: "6.7.1"),
         .package(url: "https://github.com/navermaps/SPM-NMapsMap", from: "3.20.0"),
 
     ]


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #352 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

**1. 위젯 네트워크 현대화 및 의존성 업데이트**

- **비동기 처리 전환:** `ESTimelineProvider`에서 기존 `RxSwift/RxMoya`를 제거하고 `Combine`과 `async/await` 기반으로 코드를 현대화했습니다. (`disposeBag` 삭제, `MoyaProvider async` 확장 추가)
- **타임라인 정책 개선:** 위젯 타임라인 업데이트 주기를 식사 시간에 맞춰 동적으로 조정하고, 에러 발생 시 5분 뒤에 재시도하도록 로직을 개선했습니다.
- **의존성 교체:** `Project.swift`에서 `RxSwift` 및 `RxMoya` 의존성을 제거하고, `CombineMoya`를 추가했습니다.

**2. 리뷰 UI 및 로직 간소화**

- **공란 상태 처리 변경:** `MyReviewViewController`에서 별도로 관리하던 `noMyReviewImageView`와 개수 확인 로직(`checkReviewCount`)을 제거했습니다.
- **셀 기반 뷰 구현:** 리뷰가 없을 때 `ReviewEmptyViewCell`이라는 커스텀 테이블 셀을 띄우는 방식으로 변경하여 로직과 UI 업데이트 과정을 단순화했습니다.
- **디자인 수정:** 빈 리뷰 셀에 `configureForMyReview()` 메서드를 추가하여 문구를 설정하고, 폰트 굵기를 조정해 가독성을 높였습니다.

**3. 위젯 UI 디자인 개선**

- **레이아웃 최적화:** 위젯의 에러 뷰(`ErrorView`)와 메뉴 없음 뷰(`EmptyMenuView`)의 Medium/Small 사이즈에 대해 레이아웃 간격(`Spacing`, `Padding`)과 폰트 크기를 조정하여 디자인 완성도를 높였습니다.


<img width="346" height="186" alt="image" src="https://github.com/user-attachments/assets/e456838c-0ae2-4b15-b646-b2e9b2ed424f" />
<img width="174" height="185" alt="image" src="https://github.com/user-attachments/assets/fa9c9052-3d15-43d4-b862-c97b6bb40a40" />

<img width="352" height="185" alt="image" src="https://github.com/user-attachments/assets/2d6c63d2-c440-4113-9772-bcdb8c37e92a" />
<img width="166" height="182" alt="image" src="https://github.com/user-attachments/assets/19b7a437-2809-4663-99d4-40fd4f7c7120" />

<img width="352" alt="image" src="https://github.com/user-attachments/assets/f7f7669f-82fb-45b0-82a8-b8b4ca4b48c4" />
<img width="166" alt="image" src="https://github.com/user-attachments/assets/8f999acd-ee53-4883-9752-9b830326955e" />


### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 위젯 로직 변경하면서 예전부터 신경쓰였던 UI 디자인도 손봤습니다.