### PR TITLE
[#360] 위젯 UI 버그 수정

### DIFF
--- a/EATSSU/Widget/Sources/Data/Timeline/DevTimelineProvider.swift
+++ b/EATSSU/Widget/Sources/Data/Timeline/DevTimelineProvider.swift
@@ -6,6 +6,7 @@
 //
 
 import WidgetKit
+import SwiftUI
 
 // 개발용 목업 데이터를 제공하는 타임라인 프로바이더
 struct DevTimelineProvider: AppIntentTimelineProvider {
@@ -13,21 +14,21 @@ struct DevTimelineProvider: AppIntentTimelineProvider {
     typealias Entry = ESEntry
 
     // 개발용 고정 메뉴 데이터
-    private let mockMenus = [
+    private let mockMenus: [String: [[String]]] = [
         "아침 메뉴": [
-            "현미밥", "된장찌개", "계란말이", "김치",
-            "두부조림", "시금치나물", "연근조림",
-            "미역국", "오이소박이", "콩자반",
+            ["현미밥", "된장찌개", "계란말이", "김치"],
+            ["두부조림", "시금치나물", "연근조림"],
+            ["미역국", "오이소박이", "콩자반"]
         ],
         "점심 메뉴": [
-            "스팸마요덮밥", "우동국물", "깍두기", "요거트",
-            "불고기덮밥", "된장찌개", "참치김치볶음",
-            "배추김치", "계란장조림", "사과",
+            ["스팸마요덮밥", "우동국물", "깍두기", "요거트"],
+            ["불고기덮밥", "된장찌개", "참치김치볶음"],
+            ["배추김치", "계란장조림", "사과"]
         ],
         "저녁 메뉴": [
-            "치킨텐더", "감자튀김", "콜슬로", "양상추샐러드",
-            "스테이크", "그릴드치즈", "토마토스프",
-            "브로콜리살라드", "마늘빵", "딸기요거트",
+            ["치킨텐더", "감자튀김", "콜슬로", "양상추샐러드"],
+            ["스테이크", "그릴드치즈", "토마토스프"],
+            ["브로콜리살라드", "마늘빵", "딸기요거트"]
         ],
     ]
 
@@ -37,7 +38,7 @@ struct DevTimelineProvider: AppIntentTimelineProvider {
         return ESEntry(
             date: currentDate,
             restaurantName: "개발용 식당",
-            menus: ["로딩중..."],
+            menus: [["로딩중..."]],
             timeSlot: timeSlot
         )
     }
@@ -48,7 +49,7 @@ struct DevTimelineProvider: AppIntentTimelineProvider {
         return ESEntry(
             date: currentDate,
             restaurantName: configuration.selectedRestaurant.displayName,
-            menus: ["샘플 메뉴 1", "샘플 메뉴 2"],
+            menus: [["샘플 메뉴 1", "반찬 A"], ["샘플 메뉴 2", "반찬 B"]],
             timeSlot: timeSlot
         )
     }
@@ -63,28 +64,28 @@ struct DevTimelineProvider: AppIntentTimelineProvider {
             ESEntry(
                 date: currentDate,
                 restaurantName: configuration.selectedRestaurant.displayName,
-                menus: mockMenus["아침 메뉴"] ?? [],
+                menus: mockMenus["아침 메뉴"] ?? [["정보 없음"]],
                 timeSlot: timeSlot
             )
         case "LUNCH":
             ESEntry(
                 date: currentDate,
                 restaurantName: configuration.selectedRestaurant.displayName,
-                menus: mockMenus["점심 메뉴"] ?? [],
+                menus: mockMenus["점심 메뉴"] ?? [["정보 없음"]],
                 timeSlot: timeSlot
             )
         case "DINNER":
             ESEntry(
                 date: currentDate,
                 restaurantName: configuration.selectedRestaurant.displayName,
-                menus: mockMenus["저녁 메뉴"] ?? [],
+                menus: mockMenus["저녁 메뉴"] ?? [["정보 없음"]],
                 timeSlot: timeSlot
             )
         default:
             ESEntry(
                 date: currentDate,
                 restaurantName: configuration.selectedRestaurant.displayName,
-                menus: ["영업시간이 아닙니다"],
+                menus: [["영업시간이 아닙니다"]],
                 timeSlot: timeSlot
             )
         }
@@ -94,7 +95,7 @@ struct DevTimelineProvider: AppIntentTimelineProvider {
         return Timeline(entries: [entry], policy: .after(nextUpdate))
     }
 
-    // 시간대 계산 메서드 (ESTimelineProvider와 동일)
+    // 시간대 계산 메서드
     private func getTimeSlot(for date: Date) -> String {
         let hour = Calendar.current.component(.hour, from: date)
         switch hour {
@@ -106,9 +107,18 @@ struct DevTimelineProvider: AppIntentTimelineProvider {
     }
 }
 
-// 프리뷰용 확장
+// 프리뷰 코드
 #Preview(as: .systemSmall) {
     EATSSUWidget()
 } timeline: {
-    ESEntry(date: Date(), restaurantName: "개발용 식당", menus: ["메뉴1", "메뉴2", "메뉴3"], timeSlot: "DINNER")
+    ESEntry(
+        date: Date(),
+        restaurantName: "개발용 식당",
+        menus: [
+            ["돈코츠라멘", "튀김", "단무지"],
+            ["부대덮밥", "계란후라이", "김치"],
+            ["치즈돈까스", "쫄면"]
+        ],
+        timeSlot: "LUNCH"
+    )
 }

--- a/EATSSU/Widget/Sources/Data/Timeline/ESTimelineProvider.swift
+++ b/EATSSU/Widget/Sources/Data/Timeline/ESTimelineProvider.swift
@@ -7,7 +7,6 @@
 
 import Combine
 import WidgetKit
-
 import Moya
 
 // 위젯의 타임라인 데이터를 제공하는 프로바이더 구조체
@@ -24,16 +23,21 @@ struct ESTimelineProvider: AppIntentTimelineProvider {
         return ESEntry(
             date: currentDate,
             restaurantName: "학생식당",
+            menus: [["로딩 중..."]],
             timeSlot: timeSlot,
             isError: false
         )
     }
 
-    // 위젯 미리보기에서 사용할 샘플 데이터 제공
+    // 위젯 갤러리(미리보기)에서 사용할 샘플 데이터 제공
     func snapshot(for _: SelectRestaurant, in _: Context) async -> ESEntry {
-        let mockupMenus = ["스팸마요덮밥", "우동국물", "깍두기", "요거트",
-                           "불고기덮밥", "된장찌개", "참치김치볶음",
-                           "배추김치", "계란장조림", "사과"]
+        // 각 메뉴 세트별로 배열을 분리 (2차원 배열)
+        let mockupMenus = [
+            ["스팸마요덮밥", "우동국물", "깍두기", "요거트"],
+            ["불고기덮밥", "된장찌개", "참치김치볶음"],
+            ["배추김치", "계란장조림", "사과"]
+        ]
+        
         return ESEntry(
             date: Date(),
             restaurantName: "학생식당",
@@ -62,8 +66,8 @@ struct ESTimelineProvider: AppIntentTimelineProvider {
         var timeline: Timeline<ESEntry>
         
         do {
-            // 네트워크 요청을 통해 메뉴 데이터를 가져옴
             let menus = try await fetchMenu(provider: provider, date: formattedDate, restaurant: restaurant, time: timeSlot)
+            
             let updatedEntry = ESEntry(
                 date: currentDate,
                 restaurantName: configuration.selectedRestaurant.displayName,
@@ -82,12 +86,13 @@ struct ESTimelineProvider: AppIntentTimelineProvider {
             let errorEntry = ESEntry(
                 date: currentDate,
                 restaurantName: configuration.selectedRestaurant.displayName,
-                menus: ["네트워크 연결 실패"],
+                menus: [["네트워크 연결 실패"]],
                 timeSlot: timeSlot,
                 isError: true
             )
             let retryDate = currentDate.addingTimeInterval(300)
-            timeline = Timeline(entries: [errorEntry], policy: .after(retryDate))        }
+            timeline = Timeline(entries: [errorEntry], policy: .after(retryDate))
+        }
 
         return timeline
     }
@@ -107,10 +112,14 @@ struct ESTimelineProvider: AppIntentTimelineProvider {
 
 
     // 서버에서 특정 날짜, 식당, 시간대의 메뉴 정보를 가져오는 함수
-    private func fetchMenu(provider: MoyaProvider<HomeRouter>, date: String, restaurant: String, time: String) async throws -> [String] {
+    private func fetchMenu(provider: MoyaProvider<HomeRouter>, date: String, restaurant: String, time: String) async throws -> [[String]] {
         let response = try await provider.request(.getChangeMenuTableResponse(date: date, restaurant: restaurant, time: time))
         let decoded = try response.map(BaseResponse<[ChangeMenuTableResponse]>.self)
-        return decoded.result.flatMap { $0.briefMenus.map(\.name) }
+        
+        // 결과: [ ["돈코츠", "튀김"], ["부대덮밥", "국물"] ]
+        return decoded.result.map { meal in
+            meal.briefMenus.map { $0.name }
+        }
     }
 
     // Date 객체를 "yyyyMMdd" 형식의 문자열로 변환하는 함수
@@ -136,13 +145,10 @@ struct ESTimelineProvider: AppIntentTimelineProvider {
         let hour = calendar.component(.hour, from: date)
         
         if hour < 10 {
-            // 현재 아침(0-10시) → 10시에 점심으로 전환
             return calendar.date(bySettingHour: 10, minute: 0, second: 0, of: date) ?? date
         } else if hour < 16 {
-            // 현재 점심(10-16시) → 16시에 저녁으로 전환
             return calendar.date(bySettingHour: 16, minute: 0, second: 0, of: date) ?? date
         } else {
-            // 현재 저녁(16-24시) → 다음날 0시에 아침으로 전환
             if let tomorrow = calendar.date(byAdding: .day, value: 1, to: date) {
                 return calendar.startOfDay(for: tomorrow)
             }

--- a/EATSSU/Widget/Sources/Domain/Entities/ESEntry.swift
+++ b/EATSSU/Widget/Sources/Domain/Entities/ESEntry.swift
@@ -18,8 +18,8 @@ struct ESEntry: TimelineEntry {
     /// 제공되는 메뉴 목록.
     ///
     /// 기본값은 `["메뉴가 없습니다."]`로 설정됩니다.
-    let menus: [String]
-
+    let menus: [[String]]
+    
     /// 시간대 정보.
     let timeSlot: String
 
@@ -36,7 +36,7 @@ struct ESEntry: TimelineEntry {
     ///   - menus: 제공되는 메뉴 목록. 기본값은 `["메뉴가 없습니다."]`입니다.
     ///   - timeSlot: 해당 시간대.
     ///   - isError: 오류 여부. 기본값은 `false`입니다.
-    init(date: Date, restaurantName: String, menus: [String] = ["메뉴가 없습니다."], timeSlot: String, isError: Bool = false) {
+    init(date: Date, restaurantName: String, menus: [[String]] = [["메뉴가 없습니다."]], timeSlot: String, isError: Bool = false) {
         self.date = date
         self.restaurantName = restaurantName
         self.menus = menus

--- a/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/MediumNormalView.swift
+++ b/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/MediumNormalView.swift
@@ -36,7 +36,7 @@ struct MediumNormalView: View {
             .padding(8)
 
             VStack(alignment: .leading, spacing: 10) {
-                ForEach(entry.menus, id: \.self) { menuSet in
+                ForEach(Array(entry.menus.enumerated()), id: \.offset) { index, menuSet in
                     Text(menuSet.joined(separator: " + "))
                         .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 12))
                         .foregroundStyle(.black)

--- a/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/MediumNormalView.swift
+++ b/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/MediumNormalView.swift
@@ -35,29 +35,18 @@ struct MediumNormalView: View {
             }
             .padding(8)
 
-            VStack {
-                VStack(alignment: .leading, spacing: 10) {
-                    if entry.menus.count > 1 && !entry.menus.contains(where: { $0.contains("+") }) {
-                        Text(entry.menus.joined(separator: " + "))
-                            .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 12))
-                            .foregroundStyle(.black)
-                            .lineLimit(nil)
-                            .multilineTextAlignment(.leading)
-                            .dynamicTypeSize(.xLarge ... .xxxLarge)
-                    } else {
-                        ForEach(entry.menus, id: \.self) { menu in
-                            Text(menu)
-                                .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 12))
-                                .foregroundStyle(.black)
-                                .lineLimit(nil)
-                                .multilineTextAlignment(.leading)
-                                .dynamicTypeSize(.xLarge ... .xxxLarge)
-                        }
-                    }
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(entry.menus, id: \.self) { menuSet in
+                    Text(menuSet.joined(separator: " + "))
+                        .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 12))
+                        .foregroundStyle(.black)
+                        .lineLimit(nil)
+                        .multilineTextAlignment(.leading)
+                        .dynamicTypeSize(.xLarge ... .xxxLarge)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(8)
             }
+            .frame(maxWidth: .infinity, alignment: .leading) 
+            .padding(8)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(
                 RoundedRectangle(cornerRadius: 10)

--- a/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/MediumNormalView.swift
+++ b/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/MediumNormalView.swift
@@ -37,13 +37,22 @@ struct MediumNormalView: View {
 
             VStack {
                 VStack(alignment: .leading, spacing: 10) {
-                    ForEach(entry.menus, id: \.self) { menu in
-                        Text(menu)
+                    if entry.menus.count > 1 && !entry.menus.contains(where: { $0.contains("+") }) {
+                        Text(entry.menus.joined(separator: " + "))
                             .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 12))
                             .foregroundStyle(.black)
                             .lineLimit(nil)
                             .multilineTextAlignment(.leading)
                             .dynamicTypeSize(.xLarge ... .xxxLarge)
+                    } else {
+                        ForEach(entry.menus, id: \.self) { menu in
+                            Text(menu)
+                                .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 12))
+                                .foregroundStyle(.black)
+                                .lineLimit(nil)
+                                .multilineTextAlignment(.leading)
+                                .dynamicTypeSize(.xLarge ... .xxxLarge)
+                        }
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/SmallNormalView.swift
+++ b/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/SmallNormalView.swift
@@ -39,7 +39,7 @@ struct SmallNormalView: View {
             // 메인 콘텐츠 영역 (메뉴 리스트)
             VStack {
                 VStack(alignment: .leading, spacing: 12) {
-                    ForEach(entry.menus, id: \.self) { menuSet in
+                    ForEach(Array(entry.menus.enumerated()), id: \.offset) { index, menuSet in
                         // 하나의 세트 안에 있는 반찬들을 " + "로 연결
                         Text(menuSet.joined(separator: " + "))
                             .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 11))

--- a/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/SmallNormalView.swift
+++ b/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/SmallNormalView.swift
@@ -37,13 +37,22 @@ struct SmallNormalView: View {
 
             VStack {
                 VStack(alignment: .leading, spacing: 12) {
-                    ForEach(entry.menus, id: \.self) { menu in
-                        Text(menu)
+                    if entry.menus.count > 1 && !entry.menus.contains(where: { $0.contains("+") }) {
+                        Text(entry.menus.joined(separator: " + "))
                             .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 11))
                             .foregroundStyle(.black)
                             .lineLimit(nil)
                             .multilineTextAlignment(.leading)
                             .dynamicTypeSize(.xLarge ... .xxxLarge)
+                    } else {
+                        ForEach(entry.menus, id: \.self) { menu in
+                            Text(menu)
+                                .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 11))
+                                .foregroundStyle(.black)
+                                .lineLimit(nil)
+                                .multilineTextAlignment(.leading)
+                                .dynamicTypeSize(.xLarge ... .xxxLarge)
+                        }
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/SmallNormalView.swift
+++ b/EATSSU/Widget/Sources/Presentation/Views/SuccessView/NormalView/SmallNormalView.swift
@@ -14,6 +14,7 @@ struct SmallNormalView: View {
 
     var body: some View {
         VStack(spacing: 8) {
+            // 상단 헤더 영역 (식당 이름, 시간, 로고)
             HStack {
                 Text(entry.restaurantName)
                     .font(EATSSUDesignFontFamily.Pretendard.bold.swiftUIFont(size: 10))
@@ -35,24 +36,17 @@ struct SmallNormalView: View {
             }
             .padding(8)
 
+            // 메인 콘텐츠 영역 (메뉴 리스트)
             VStack {
                 VStack(alignment: .leading, spacing: 12) {
-                    if entry.menus.count > 1 && !entry.menus.contains(where: { $0.contains("+") }) {
-                        Text(entry.menus.joined(separator: " + "))
+                    ForEach(entry.menus, id: \.self) { menuSet in
+                        // 하나의 세트 안에 있는 반찬들을 " + "로 연결
+                        Text(menuSet.joined(separator: " + "))
                             .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 11))
                             .foregroundStyle(.black)
-                            .lineLimit(nil)
+                            .lineLimit(nil) 
                             .multilineTextAlignment(.leading)
                             .dynamicTypeSize(.xLarge ... .xxxLarge)
-                    } else {
-                        ForEach(entry.menus, id: \.self) { menu in
-                            Text(menu)
-                                .font(EATSSUDesignFontFamily.Pretendard.medium.swiftUIFont(size: 11))
-                                .foregroundStyle(.black)
-                                .lineLimit(nil)
-                                .multilineTextAlignment(.leading)
-                                .dynamicTypeSize(.xLarge ... .xxxLarge)
-                        }
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #360 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

**핵심 변경 사항**
- **데이터 구조 리팩토링 ([String] → [[String]])**
  - 위젯 타임라인과 뷰에서 사용하는 메뉴 데이터 구조를 기존의 1차원 배열에서 2차원 배열로 변경했습니다.
  - 이를 통해 메인 메뉴와 반찬 등 연관된 메뉴 아이템을 하나의 그룹으로 묶어서 관리할 수 있게 되었습니다.

**세부 업데이트 내역**

- **Core Data 모델 수정**
  - ESEntry 모델의 menus 속성 타입과 초기화(Initializer) 구문을 새로운 구조에 맞게 수정했습니다.
  - DevTimelineProvider와 ESTimelineProvider의 Mock 데이터, 로딩/에러 상태 데이터, Fetch 로직을 모두 [[String]] 타입을 처리하도록 업데이트했습니다.

**위젯 뷰(View) 로직 개선**
- MediumNormalView와 SmallNormalView에서 메뉴 데이터를 표시하는 방식을 변경했습니다.
- 각 메뉴 그룹(배열)을 순회하며, 내부 아이템들을 " + " 문자열로 연결하여 한 줄로 표시하도록 수정했습니다 (예: 메인 + 반찬).

**네트워크 및 기타**
- ESTimelineProvider의 네트워크 Fetch 로직을 수정하여 2차원 배열 형태의 메뉴 데이터를 반환하도록 했습니다.
- 새로운 데이터 구조에 맞춰 주석(Comments)과 프리뷰(Preview) 코드를 정리했습니다.

<img width="192" height="197" alt="image" src="https://github.com/user-attachments/assets/72903944-8812-4a81-ba62-64530e352814" />
<img width="353" height="176" alt="image" src="https://github.com/user-attachments/assets/246833f2-d866-4fe0-9086-1fb55cc263dd" />
<img width="177" height="202" alt="image" src="https://github.com/user-attachments/assets/a2f9f191-fa0d-47f7-a7c5-b93a14e6c4f0" />
<img width="381" height="191" alt="image" src="https://github.com/user-attachments/assets/d8bb613d-d42f-4f9a-b812-0b6301426de5" />


### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
