### PR TITLE
[#377] TextLiteral 세팅 완료

### DIFF
--- a/EATSSU/App/Sources/Data/Firebase/HomeAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/HomeAnalyticsManager.swift
@@ -35,17 +35,17 @@ final class HomeAnalyticsManager {
         
     // 식당 이름(한글) -> 영문 소문자 파라미터로 변환
     private let restaurantNameMap: [String: String] = [
-        TextLiteral.studentRestaurant: "haksik",
-        TextLiteral.dodamRestaurant: "dodam",
-        TextLiteral.dormitoryRestaurant: "dormitory",
-        TextLiteral.facultyRestaurant: "faculty"
+        TextLiteral.Restaurant.studentRestaurant: "haksik",
+        TextLiteral.Restaurant.dodamRestaurant: "dodam",
+        TextLiteral.Restaurant.dormitoryRestaurant: "dormitory",
+        TextLiteral.Restaurant.facultyRestaurant: "faculty"
     ]
     
     // 식사 유형(한글) -> 영문 소문자 파라미터로 변환
     private let mealTimeMap: [String: String] = [
-        TextLiteral.morning: "breakfast",
-        TextLiteral.lunch: "lunch",
-        TextLiteral.dinner: "dinner"
+        TextLiteral.Home.morning: "breakfast",
+        TextLiteral.Home.lunch: "lunch",
+        TextLiteral.Home.dinner: "dinner"
     ]
     
     // Date 객체 -> 요일(영문 소문자) 문자열로 변환

--- a/EATSSU/App/Sources/Presentation/Auth/Enum/NIcknameTextFieldResultType.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/Enum/NIcknameTextFieldResultType.swift
@@ -32,37 +32,37 @@ enum NicknameTextFieldResultType {
     var hintMessage: String {
         switch self {
         case .textFieldEmpty:
-            "필수 입력 사항입니다"
+            TextLiteral.Auth.requiredInput
         case .nicknameTextFieldDoubleCheck:
-            "중복 확인을 진행해주세요."
+            TextLiteral.Auth.needCheckDuplicate
         case .nicknameTextFieldDuplicated:
-            "이미 사용 중인 닉네임이에요."
+            TextLiteral.Auth.duplicatedNickname
         case .nicknameTextFieldValid:
-            "사용가능한 닉네임이에요"
+            TextLiteral.Auth.availableNickname
         case .invalidLength:
-            "2~16글자를 입력해 주세요."
+            TextLiteral.Auth.nicknameLength
         case .invalidStartOrEnd:
-            "특수문자로 시작/끝나는 닉네임은 사용할 수 없어요."
+            TextLiteral.Auth.specialCharNickname
         case .consecutiveSpecialChars:
-            "연속된 특수문자(--, __)는 사용할 수 없어요."
+            TextLiteral.Auth.continuousSpecialChar
         case .onlyNumbers:
-            "숫자만으로 된 닉네임은 사용할 수 없어요."
+            TextLiteral.Auth.numberOnlyNickname
         case .invalidCharacters:
-            "허용 문자(한글/영문/숫자)만 사용할 수 있어요."
+            TextLiteral.Auth.allowedChar
         case .bannedWord:
-            "사용할 수 없는 단어가 포함되어 있어요."
+            TextLiteral.Auth.bannedWord
         case .whitespaceAtStartOrEnd:
-            "띄어쓰기로 시작/끝나는 닉네임은 사용할 수 없어요."
+            TextLiteral.Auth.spaceNickname
         case .consecutiveWhitespace:
-            "연속된 띄어쓰기는 사용할 수 없어요."
+            TextLiteral.Auth.continuousSpace
         case .emojiOrSpecialChar:
-            "이모지, 특수문자는 사용할 수 없어요."
+            TextLiteral.Auth.emojiSpecialChar
         case .adminRelatedWord:
-            "관리자로 혼동될 수 있는 닉네임은 사용할 수 없어요."
+            TextLiteral.Auth.adminNickname
         case .serviceNameWord:
-            "서비스명 단독 닉네임은 사용할 수 없어요."
+            TextLiteral.Auth.serviceNameNickname
         case .profanityWord:
-            "욕설, 비속어 등의 표현이 포함된 닉네임은 사용할 수 없어요."
+            TextLiteral.Auth.slangNickname
         }
     }
 

--- a/EATSSU/App/Sources/Presentation/Auth/View/SetNickNameView.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/View/SetNickNameView.swift
@@ -235,7 +235,7 @@ final class SetNickNameView: BaseUIView {
         if let accountType = UserInfoManager.shared.getCurrentUserInfo()?.accountType {
             switch accountType {
             case .apple:
-                accountTypeLabel.text = "APPLE"
+                accountTypeLabel.text = TextLiteral.Auth.apple
                 accountTypeImage.image = EATSSUDesignAsset.Images.signWithApple.image
             case .kakao:
                 accountTypeLabel.text = TextLiteral.Auth.kakao

--- a/EATSSU/App/Sources/Presentation/Auth/View/SetNickNameView.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/View/SetNickNameView.swift
@@ -15,8 +15,8 @@ final class SetNickNameView: BaseUIView {
     // MARK: - Properties
 
     private var userNickname: String = ""
-    public let collegeDropDownView = DropDownView(title: "단과대", items: [])
-    public let departmentDropDownView = DropDownView(title: "학과", items: [])
+    public let collegeDropDownView = DropDownView(title: TextLiteral.Auth.college, items: [])
+    public let departmentDropDownView = DropDownView(title: TextLiteral.Auth.department, items: [])
     private var isNicknameChecked = false
     private var selectedCollege: String?
     private var selectedDepartment: String?
@@ -28,25 +28,25 @@ final class SetNickNameView: BaseUIView {
 
     private let nickNameLabel: UILabel = {
         let label = UILabel()
-        label.text = "닉네임 설정"
+        label.text = TextLiteral.Auth.setNickname
         label.font = EATSSUDesignFontFamily.Pretendard.regular.font(size: 14)
         return label
     }()
 
     public let inputNickNameTextField: ESTextField = {
-        let textField = ESTextField(placeholder: TextLiteral.inputNickName)
+        let textField = ESTextField(placeholder: TextLiteral.Auth.inputNickName)
         return textField
     }()
 
     public var nicknameDoubleCheckButton: ESButton = {
-        let button = ESButton(size: .small, title: "중복 확인")
+        let button = ESButton(size: .small, title: TextLiteral.Auth.checkDuplicate)
         button.isEnabled = false
         return button
     }()
 
     public var nicknameValidationMessageLabel: UILabel = {
         let label = UILabel()
-        label.text = TextLiteral.hintInputNickName
+        label.text = TextLiteral.Auth.nicknameLength
         label.textColor = .gray400
         label.font = EATSSUDesignFontFamily.Pretendard.regular.font(size: 12)
         return label
@@ -64,7 +64,7 @@ final class SetNickNameView: BaseUIView {
 
     private let affiliationLabel: UILabel = {
         let label = UILabel()
-        label.text = "소속 설정"
+        label.text = TextLiteral.Auth.setCollege
         label.font = EATSSUDesignFontFamily.Pretendard.regular.font(size: 14)
         return label
     }()
@@ -81,14 +81,14 @@ final class SetNickNameView: BaseUIView {
 
     private let connectedAccountLabel: UILabel = {
         let label = UILabel()
-        label.text = "연결된 계정"
+        label.text = TextLiteral.Auth.linkedAccount
         label.font = EATSSUDesignFontFamily.Pretendard.regular.font(size: 14)
         return label
     }()
 
     private let accountTypeLabel: UILabel = {
         let label = UILabel()
-        label.text = "없음"
+        label.text = TextLiteral.Auth.empty
         label.font = .button2
         return label
     }()
@@ -122,7 +122,7 @@ final class SetNickNameView: BaseUIView {
     }()
 
     public var completeSettingNickNameButton: ESButton = {
-        let button = ESButton(size: .big, title: "저장하기")
+        let button = ESButton(size: .big, title: TextLiteral.Auth.save)
         button.isEnabled = false
         return button
     }()
@@ -205,7 +205,7 @@ final class SetNickNameView: BaseUIView {
             selectedCollege = college
 
             departmentDropDownView.updateItems([])
-            departmentDropDownView.setTitle("학과")
+            departmentDropDownView.setTitle(TextLiteral.Auth.department)
             selectedDepartment = nil
             updateCompleteButtonState()
 
@@ -221,8 +221,8 @@ final class SetNickNameView: BaseUIView {
     }
 
     private func updateCompleteButtonState() {
-        let isCollegeSelected = selectedCollege != nil && selectedCollege != "단과대"
-        let isDepartmentSelected = selectedDepartment != nil && selectedDepartment != "학과"
+        let isCollegeSelected = selectedCollege != nil && selectedCollege != TextLiteral.Auth.college
+        let isDepartmentSelected = selectedDepartment != nil && selectedDepartment != TextLiteral.Auth.department
         completeSettingNickNameButton.isEnabled = isNicknameChecked && isCollegeSelected && isDepartmentSelected
     }
 
@@ -238,7 +238,7 @@ final class SetNickNameView: BaseUIView {
                 accountTypeLabel.text = "APPLE"
                 accountTypeImage.image = EATSSUDesignAsset.Images.signWithApple.image
             case .kakao:
-                accountTypeLabel.text = "카카오"
+                accountTypeLabel.text = TextLiteral.Auth.kakao
                 accountTypeImage.image = EATSSUDesignAsset.Images.signWithKakao.image
             }
         }

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
@@ -194,9 +194,9 @@ extension LoginViewController {
         } catch {
             switch accountType {
             case .apple:
-                showToast(message: "카카오톡으로 생성된 계정입니다.", type: .warning)
+                showToast(message: TextLiteral.Auth.kakaoAccount, type: .warning)
             case .kakao:
-                showToast(message: "Apple로 생성된 계정입니다.", type: .warning)
+                showToast(message: TextLiteral.Auth.appleAccount, type: .warning)
             }
 
             #if DEBUG
@@ -226,7 +226,7 @@ extension LoginViewController {
                 getMyInfo()
                 
             case .failure(let error):
-                showToast(message: "카카오톡으로 생성된 계정입니다.", type: .warning)
+                showToast(message: TextLiteral.Auth.kakaoAccount, type: .warning)
                 #if DEBUG
                     print(error.localizedDescription)
                 #endif
@@ -254,7 +254,7 @@ extension LoginViewController {
                 getMyInfo()
                 
             case .failure(let error):
-                showToast(message: "Apple로 생성된 계정입니다.", type: .warning)
+                showToast(message: TextLiteral.Auth.appleAccount, type: .warning)
                 #if DEBUG
                     print(error.localizedDescription)
                 #endif

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/SetNickNameViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/SetNickNameViewController.swift
@@ -82,7 +82,7 @@ final class SetNickNameViewController: BaseViewController {
     
     override func setCustomNavigationBar() {
         super.setCustomNavigationBar()
-        navigationItem.title = TextLiteral.setNickName
+        navigationItem.title = TextLiteral.Auth.setNickname
     }
     
     private func bindUI() {
@@ -110,7 +110,7 @@ final class SetNickNameViewController: BaseViewController {
         let departmentChanged = isDepartmentChanged()
         
         guard hasNicknameChanged || departmentChanged else {
-            print("변경된 정보가 없습니다.")
+            print(TextLiteral.Auth.noChanges)
             return
         }
 
@@ -129,7 +129,7 @@ final class SetNickNameViewController: BaseViewController {
         if departmentChanged {
             guard let departmentName = setNickNameView.departmentDropDownView.getSelectedTitle(),
                   let departmentId = self.departments.first(where: { $0.name == departmentName })?.id else {
-                print("유효하지 않은 학과 정보입니다.")
+                print(TextLiteral.Auth.invalidDepartment)
                 return
             }
             let collegeName = setNickNameView.collegeDropDownView.getSelectedTitle()
@@ -147,7 +147,7 @@ final class SetNickNameViewController: BaseViewController {
             if isNicknameUpdateSuccess && isDepartmentUpdateSuccess {
                 self.navigateToMyPageWithToast()
             } else {
-                self.showToast(message: "정보 업데이트 중 오류가 발생했습니다.", type: .danger)
+                self.showToast(message: TextLiteral.Auth.updateError, type: .danger)
             }
         }
     }
@@ -160,7 +160,7 @@ final class SetNickNameViewController: BaseViewController {
             self.navigationController?.popToViewController(myPageVC, animated: true)
             
             DispatchQueue.main.asyncAfter(deadline: .now()) {
-                myPageVC.showToast(message: "내 정보가 수정되었어요.", type: .success)
+                myPageVC.showToast(message: TextLiteral.Auth.updateSuccess, type: .success)
             }
         } else {
             let homeVC = HomeViewController()
@@ -183,7 +183,7 @@ final class SetNickNameViewController: BaseViewController {
     /// 학과 변경 여부를 명확하게 판단하는 헬퍼 메서드
     private func isDepartmentChanged() -> Bool {
         guard let selectedDepartment = setNickNameView.departmentDropDownView.getSelectedTitle(),
-              selectedDepartment != "학과"
+              selectedDepartment != TextLiteral.Auth.department
         else {
             return false
         }
@@ -269,7 +269,7 @@ final class SetNickNameViewController: BaseViewController {
     
     private func navigateToLogin() {
         let loginVC = LoginViewController()
-        loginVC.toastMessage = "세션이 만료되었습니다. 다시 로그인해주세요."
+        loginVC.toastMessage = TextLiteral.Common.sessionExpired
         loginVC.toastType = .info
         
         DispatchQueue.main.async {

--- a/EATSSU/App/Sources/Presentation/Home/View/RestaurantInfoView/RestaurantInfoView.swift
+++ b/EATSSU/App/Sources/Presentation/Home/View/RestaurantInfoView/RestaurantInfoView.swift
@@ -19,35 +19,35 @@ final class RestaurantInfoView: BaseUIView {
 
     var restaurantNameLabel: UILabel = {
         let label = UILabel()
-        label.text = "학생 식당"
+        label.text = TextLiteral.Home.studentRestaurant
         label.font = EATSSUDesignFontFamily.Pretendard.bold.font(size: 20)
         return label
     }()
 
     private let locationTitleLabel: UILabel = {
         let label = UILabel()
-        label.text = "식당 위치"
+        label.text = TextLiteral.Home.restaurantLocation
         label.font = EATSSUDesignFontFamily.Pretendard.bold.font(size: 18)
         return label
     }()
 
     private let imageTitleLabel: UILabel = {
         let label = UILabel()
-        label.text = "식당 사진"
+        label.text = TextLiteral.Home.restaurantPicture
         label.font = EATSSUDesignFontFamily.Pretendard.bold.font(size: 18)
         return label
     }()
 
     private var locationLabel: UILabel = {
         let label = UILabel()
-        label.text = "숭실대학교"
+        label.text = TextLiteral.Home.soongsilUniversity
         label.font = EATSSUDesignFontFamily.Pretendard.medium.font(size: 16)
         return label
     }()
 
     private let openingTimeTitleLabel: UILabel = {
         let label = UILabel()
-        label.text = "영업 시간"
+        label.text = TextLiteral.Home.businessHour
         label.font = EATSSUDesignFontFamily.Pretendard.bold.font(size: 18)
         return label
     }()
@@ -68,7 +68,7 @@ final class RestaurantInfoView: BaseUIView {
 
     private let ectTitleLabel: UILabel = {
         let label = UILabel()
-        label.text = "비고"
+        label.text = TextLiteral.Home.note
         label.font = EATSSUDesignFontFamily.Pretendard.bold.font(size: 18)
         return label
     }()
@@ -78,7 +78,7 @@ final class RestaurantInfoView: BaseUIView {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = 10
         label.attributedText = NSAttributedString(
-            string: "아시안푸드, 돈까스, 샐러드, 국밥 등\n카페",
+            string: TextLiteral.Home.dodamEtc,
             attributes: [NSAttributedString.Key.paragraphStyle: paragraphStyle]
         )
         label.numberOfLines = 0

--- a/EATSSU/App/Sources/Presentation/Home/View/RestaurantTableView/RestaurantMenuGroupCell.swift
+++ b/EATSSU/App/Sources/Presentation/Home/View/RestaurantTableView/RestaurantMenuGroupCell.swift
@@ -34,7 +34,7 @@ final class RestaurantMenuGroupCell: BaseTableViewCell {
 
     private let emptyLabel: UILabel = {
         let label = UILabel()
-        label.text = "영업 시간이 아니에요."
+        label.text = TextLiteral.Home.notBusinessHour
         label.font = EATSSUDesignFontFamily.Pretendard.regular.font(size: 10)
         label.textColor = .black
         label.textAlignment = .center

--- a/EATSSU/App/Sources/Presentation/Home/View/RestaurantTableView/RestaurantTableViewHeader.swift
+++ b/EATSSU/App/Sources/Presentation/Home/View/RestaurantTableView/RestaurantTableViewHeader.swift
@@ -32,7 +32,7 @@ class RestaurantTableViewHeader: BaseTableViewHeaderView {
 
     func setViewProperties() {
         titleLabel.font = EATSSUDesignFontFamily.Pretendard.bold.font(size: 16)
-        titleLabel.text = "기숙사 식당"
+        titleLabel.text = TextLiteral.Home.dormitoryRestaurant
 
         var configuration = UIButton.Configuration.plain()
         configuration.baseForegroundColor = .gray600

--- a/EATSSU/App/Sources/Presentation/Home/ViewController/CustomTimeTabController.swift
+++ b/EATSSU/App/Sources/Presentation/Home/ViewController/CustomTimeTabController.swift
@@ -15,7 +15,7 @@ import EATSSUDesign
 final class CustomTimeTabController: BaseViewController {
     // MARK: - Properties
 
-    private let tabTitles = ["아침", "점심", "저녁"]
+    private let tabTitles = [TextLiteral.Home.morning, TextLiteral.Home.lunch, TextLiteral.Home.dinner]
     private var selectedIndex: Int = 0 {
         didSet {
             updateTabSelection(animated: true)

--- a/EATSSU/App/Sources/Presentation/Home/ViewController/HomeRestaurantViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Home/ViewController/HomeRestaurantViewController.swift
@@ -44,18 +44,18 @@ final class HomeRestaurantViewController: BaseViewController {
     private let fixedDummy = FixedMenuInfoData.Dummy()
 
     // 섹션 헤더에 들어갈 식당명 문자열 배열
-    private let sectionHeaderRestaurant = [TextLiteral.studentRestaurant,
-                                           TextLiteral.dodamRestaurant,
-                                           TextLiteral.dormitoryRestaurant,
-                                           TextLiteral.facultyRestaurant,
-                                           TextLiteral.snackCorner]
+    private let sectionHeaderRestaurant = [TextLiteral.Restaurant.studentRestaurant,
+                                           TextLiteral.Restaurant.dodamRestaurant,
+                                           TextLiteral.Restaurant.dormitoryRestaurant,
+                                           TextLiteral.Restaurant.facultyRestaurant,
+                                           TextLiteral.Restaurant.snackCorner]
 
     // 버튼에 표시되는 타이틀을 백엔드 식당 이름으로 매핑
-    let restaurantButtonTitleToName = [TextLiteral.studentRestaurant: "HAKSIK",
-                                       TextLiteral.dodamRestaurant: "DODAM",
-                                       TextLiteral.dormitoryRestaurant: "DORMITORY",
-                                       TextLiteral.facultyRestaurant: "FACULTY",
-                                       TextLiteral.snackCorner: "SNACK_CORNER"]
+    let restaurantButtonTitleToName = [TextLiteral.Restaurant.studentRestaurant: "HAKSIK",
+                                       TextLiteral.Restaurant.dodamRestaurant: "DODAM",
+                                       TextLiteral.Restaurant.dormitoryRestaurant: "DORMITORY",
+                                       TextLiteral.Restaurant.facultyRestaurant: "FACULTY",
+                                       TextLiteral.Restaurant.snackCorner: "SNACK_CORNER"]
     
     // 변경 메뉴를 가져올 식당 식별자 목록(스낵 제외)
     private var changeRestaurantIDs: [String] {
@@ -165,7 +165,7 @@ final class HomeRestaurantViewController: BaseViewController {
         let weekday = Weekday.from(date: date)
         isWeekend = weekday.isWeekend
 
-        if time == TextLiteral.lunchRawValue {
+        if time == "LUNCH" {
             // 학기 중 평일 점심에만 스낵 고정 메뉴 요청
             if !FirebaseRemoteConfig.shared.isVacationPeriod, !weekday.isWeekend {
                 isSelectable = true
@@ -286,10 +286,10 @@ extension HomeRestaurantViewController: UITableViewDataSource {
     }
     
     private func presentLoginAlert() {
-        let alert = UIAlertController(title: "로그인이 필요한 서비스입니다",
-                                      message: "로그인 하시겠습니까?",
+        let alert = UIAlertController(title: TextLiteral.Common.needLogin,
+                                      message: TextLiteral.Common.askLogin,
                                       preferredStyle: .alert)
-        let confirm = UIAlertAction(title: "확인", style: .default) { _ in
+        let confirm = UIAlertAction(title: TextLiteral.Common.confirm, style: .default) { _ in
             let loginVC = LoginViewController()
             if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                let sceneDelegate = windowScene.delegate as? SceneDelegate,
@@ -298,7 +298,7 @@ extension HomeRestaurantViewController: UITableViewDataSource {
             }
         }
         alert.addAction(confirm)
-        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        alert.addAction(UIAlertAction(title: TextLiteral.Common.cancel, style: .cancel))
         present(alert, animated: true)
     }
 

--- a/EATSSU/App/Sources/Presentation/Home/ViewController/HomeRestaurantViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Home/ViewController/HomeRestaurantViewController.swift
@@ -23,6 +23,21 @@ protocol RestaurantInfoDelegate: AnyObject {
 }
 
 final class HomeRestaurantViewController: BaseViewController {
+    
+    private enum RestaurantIdentifier: String, CaseIterable {
+        case haksik = "HAKSIK"
+        case dodam = "DODAM"
+        case dormitory = "DORMITORY"
+        case faculty = "FACULTY"
+        case snackCorner = "SNACK_CORNER"
+    }
+
+    private enum MealTime: String {
+        case morning = "MORNING"
+        case lunch = "LUNCH"
+        case dinner = "DINNER"
+    }
+    
     // MARK: - Properties
     
     // Combine 요청을 관리하기 위한 Set
@@ -51,17 +66,17 @@ final class HomeRestaurantViewController: BaseViewController {
                                            TextLiteral.Restaurant.snackCorner]
 
     // 버튼에 표시되는 타이틀을 백엔드 식당 이름으로 매핑
-    let restaurantButtonTitleToName = [TextLiteral.Restaurant.studentRestaurant: "HAKSIK",
-                                       TextLiteral.Restaurant.dodamRestaurant: "DODAM",
-                                       TextLiteral.Restaurant.dormitoryRestaurant: "DORMITORY",
-                                       TextLiteral.Restaurant.facultyRestaurant: "FACULTY",
-                                       TextLiteral.Restaurant.snackCorner: "SNACK_CORNER"]
+    let restaurantButtonTitleToName = [TextLiteral.Restaurant.studentRestaurant: RestaurantIdentifier.haksik.rawValue,
+                                       TextLiteral.Restaurant.dodamRestaurant: RestaurantIdentifier.dodam.rawValue,
+                                       TextLiteral.Restaurant.dormitoryRestaurant: RestaurantIdentifier.dormitory.rawValue,
+                                       TextLiteral.Restaurant.facultyRestaurant: RestaurantIdentifier.faculty.rawValue,
+                                       TextLiteral.Restaurant.snackCorner: RestaurantIdentifier.snackCorner.rawValue]
     
     // 변경 메뉴를 가져올 식당 식별자 목록(스낵 제외)
     private var changeRestaurantIDs: [String] {
-        sectionHeaderRestaurant
-            .compactMap { restaurantButtonTitleToName[$0] }
-            .filter { $0 != Restaurant.snackCorner.identifier }
+        RestaurantIdentifier.allCases
+            .map { $0.rawValue }
+            .filter { $0 != RestaurantIdentifier.snackCorner.rawValue }
     }
     
     // info 버튼 UIAction 고정 식별자
@@ -165,17 +180,17 @@ final class HomeRestaurantViewController: BaseViewController {
         let weekday = Weekday.from(date: date)
         isWeekend = weekday.isWeekend
 
-        if time == "LUNCH" {
+        if time == MealTime.lunch.rawValue {
             // 학기 중 평일 점심에만 스낵 고정 메뉴 요청
             if !FirebaseRemoteConfig.shared.isVacationPeriod, !weekday.isWeekend {
                 isSelectable = true
                 let fixTask = _Concurrency.Task {
-                    await self.fetchFixedMenuData(restaurant: Restaurant.snackCorner.identifier)
+                    await self.fetchFixedMenuData(restaurant: RestaurantIdentifier.snackCorner.rawValue)
                 }
                 cancellables.insert(AnyCancellable { fixTask.cancel() })
             } else {
                 // 방학/주말 더미
-                fixMenuTableViewData[Restaurant.snackCorner.identifier] = []
+                fixMenuTableViewData[RestaurantIdentifier.snackCorner.rawValue] = []
             }
         }
     }
@@ -209,7 +224,7 @@ extension HomeRestaurantViewController: UITableViewDataSource {
         ) as! RestaurantMenuGroupCell
 
         let sectionKey = getSectionKey(for: indexPath.section)
-        let isSnackCorner = (sectionKey == Restaurant.snackCorner.identifier)
+        let isSnackCorner = (sectionKey == RestaurantIdentifier.snackCorner.rawValue)
 
         let menuList: [MenuTypeInfo] = isSnackCorner
             ? (fixMenuTableViewData[sectionKey]?.map { .fix($0) } ?? [])
@@ -235,7 +250,7 @@ extension HomeRestaurantViewController: UITableViewDataSource {
             HomeAnalyticsManager.shared.logClickMenu(restaurantName: restaurantName)
         }
         
-        let isSnackCorner = (restaurant == Restaurant.snackCorner.identifier)
+        let isSnackCorner = (restaurant == RestaurantIdentifier.snackCorner.rawValue)
 
         var reviewMenuTypeInfo = ReviewMenuTypeInfo(menuType: "", menuID: 0)
 

--- a/EATSSU/App/Sources/Presentation/Map/View/MainMapView.swift
+++ b/EATSSU/App/Sources/Presentation/Map/View/MainMapView.swift
@@ -42,7 +42,7 @@ final class MainMapView: BaseUIView {
         let titleFont = UIFont.button2
 
         // 전체 버튼
-        wholeButton.setTitle("전체", for: .normal)
+        wholeButton.setTitle(TextLiteral.Map.all, for: .normal)
         wholeButton.titleLabel?.font = titleFont
         wholeButton.layer.cornerRadius = 14
         wholeButton.clipsToBounds = true
@@ -50,7 +50,7 @@ final class MainMapView: BaseUIView {
         wholeButton.setTitleColor(.label, for: .normal)
         if #available(iOS 15.0, *) {
             var cfg = wholeButton.configuration ?? .plain()
-            cfg.title = "전체"
+            cfg.title = TextLiteral.Map.all
             cfg.baseForegroundColor = .label
             cfg.baseBackgroundColor = .clear
             cfg.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12)
@@ -65,7 +65,7 @@ final class MainMapView: BaseUIView {
         }
 
         // 내 제휴 버튼
-        myOnlyButton.setTitle("내 제휴", for: .normal)
+        myOnlyButton.setTitle(TextLiteral.Map.myPartner, for: .normal)
         myOnlyButton.titleLabel?.font = titleFont
         myOnlyButton.layer.cornerRadius = 14
         myOnlyButton.clipsToBounds = true
@@ -73,7 +73,7 @@ final class MainMapView: BaseUIView {
         myOnlyButton.setTitleColor(.label, for: .normal)
         if #available(iOS 15.0, *) {
             var cfg = myOnlyButton.configuration ?? .plain()
-            cfg.title = "내 제휴"
+            cfg.title = TextLiteral.Map.myPartner
             cfg.baseForegroundColor = .label
             cfg.baseBackgroundColor = .clear
             cfg.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12)

--- a/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController+Location.swift
+++ b/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController+Location.swift
@@ -76,18 +76,18 @@ extension MainMapViewController: CLLocationManagerDelegate {
     
     func showLocationPermissionAlert() {
         let alert = UIAlertController(
-            title: "위치 권한 필요",
-            message: "지도에서 내 위치를 바로 확인하고, 현재 위치 주변의 제휴점들을 손쉽게 찾아볼 수 있도록 위치 권한을 허용해 주세요.",
+            title: TextLiteral.Map.needLocationAuth,
+            message: TextLiteral.Map.locationAuthDescription,
             preferredStyle: .alert
         )
         
-        let settingsAction = UIAlertAction(title: "설정으로 이동", style: .default) { _ in
+        let settingsAction = UIAlertAction(title: TextLiteral.Common.moveToSetting, style: .default) { _ in
             if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
                 UIApplication.shared.open(settingsURL)
             }
         }
         
-        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        let cancelAction = UIAlertAction(title: TextLiteral.Common.cancel, style: .cancel)
         
         alert.addAction(settingsAction)
         alert.addAction(cancelAction)

--- a/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController+Network.swift
+++ b/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController+Network.swift
@@ -42,7 +42,7 @@ extension MainMapViewController {
                 self.currentDepartmentId = department.departmentId
                 self.currentCollegeId = department.collegeId
                 
-                let buttonTitle = departmentName.isEmpty ? "내 제휴" : departmentName
+                let buttonTitle = departmentName.isEmpty ? TextLiteral.Map.myPartner : departmentName
                 self.root.myOnlyButton.setTitle(buttonTitle, for: .normal)
                 
             case .failure(let error):
@@ -50,7 +50,7 @@ extension MainMapViewController {
                 self.currentDepartmentName = nil
                 self.currentDepartmentId = nil
                 self.currentCollegeId = nil
-                self.root.myOnlyButton.setTitle("내 제휴", for: .normal)
+                self.root.myOnlyButton.setTitle(TextLiteral.Map.myPartner, for: .normal)
             }
             
             completion?()

--- a/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController.swift
@@ -95,7 +95,7 @@ final class MainMapViewController: BaseViewController {
     // MARK: - Configuration
     
     private func configureNavigationBar() {
-        title = "제휴 지도"
+        title = TextLiteral.Map.map
         let navBarAppearance = UINavigationBarAppearance()
         navBarAppearance.configureWithOpaqueBackground()
         navBarAppearance.backgroundColor = .white
@@ -201,7 +201,7 @@ final class MainMapViewController: BaseViewController {
         if let departmentName = currentDepartmentName, !departmentName.isEmpty {
             root.myOnlyButton.setTitle(departmentName, for: .normal)
         } else {
-            root.myOnlyButton.setTitle("내 제휴", for: .normal)
+            root.myOnlyButton.setTitle(TextLiteral.Map.myPartner, for: .normal)
         }
     }
 }

--- a/EATSSU/App/Sources/Presentation/Map/ViewController/NoDepartmentSheetViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Map/ViewController/NoDepartmentSheetViewController.swift
@@ -18,7 +18,7 @@ final class NoDepartmentSheetViewController: BaseViewController {
 
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.text = "학과를 입력하고\n나만의 제휴를 확인해보세요!"
+        label.text = TextLiteral.Map.inputDepartment
         label.numberOfLines = 2
         label.font = EATSSUDesignFontFamily.Pretendard.bold.font(size: 18)
         label.textColor = .label
@@ -41,7 +41,7 @@ final class NoDepartmentSheetViewController: BaseViewController {
     }()
 
     private let inputButton: ESButton = {
-        let button = ESButton(size: .big, title: "학과 입력하기")
+        let button = ESButton(size: .big, title: TextLiteral.Map.inputDepartmentButton)
         button.isEnabled = true
         return button
     }()

--- a/EATSSU/App/Sources/Presentation/Map/ViewController/PartnershipDetailSheetViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Map/ViewController/PartnershipDetailSheetViewController.swift
@@ -112,13 +112,13 @@ final class PartnershipDetailSheetViewController: BaseViewController {
         switch restaurantType {
         case "RESTAURANT":
             typeIconImageView.image = EATSSUDesignAsset.Images.restaurantPin.image
-            typeTextLabel.text = "음식점"
+            typeTextLabel.text = TextLiteral.Map.restaurant
         case "CAFE":
             typeIconImageView.image = EATSSUDesignAsset.Images.cafePin.image
-            typeTextLabel.text = "카페"
+            typeTextLabel.text = TextLiteral.Map.cafe
         case "PUB":
             typeIconImageView.image = EATSSUDesignAsset.Images.pubPin.image
-            typeTextLabel.text = "주점"
+            typeTextLabel.text = TextLiteral.Map.pub
         default:
             typeIconImageView.image = EATSSUDesignAsset.Images.restaurantPin.image
             typeTextLabel.text = restaurantType
@@ -144,7 +144,7 @@ final class PartnershipDetailSheetViewController: BaseViewController {
     
     /// 제휴 정보 카드 뷰 생성
     private func makeInfoCard(info: PartnershipInfoDTO, isLast: Bool) -> UIView {
-        let labelText = info.collegeName ?? info.departmentName ?? "학과 정보 없음"
+        let labelText = info.collegeName ?? info.departmentName ?? TextLiteral.Map.noDepartmentInfo
         
         let start = String(info.startDate.dropFirst(2))
         let end = String(info.endDate.dropFirst(2))

--- a/EATSSU/App/Sources/Presentation/MyPage/Model/MyPageLocalData.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/Model/MyPageLocalData.swift
@@ -19,7 +19,7 @@ extension MyPageLocalData {
         MyPageLocalData(titleLabel: TextLiteral.MyPage.pushNotificationSetting),
 
         // "내 정보"
-        MyPageLocalData(titleLabel: TextLiteral.MyPage.MyInfo),
+        MyPageLocalData(titleLabel: TextLiteral.MyPage.myInfo),
         
         // "내 리뷰"
         MyPageLocalData(titleLabel: TextLiteral.MyPage.myReview),

--- a/EATSSU/App/Sources/Presentation/MyPage/View/MyPageView/Cell/NotificationSettingTableViewCell.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/View/MyPageView/Cell/NotificationSettingTableViewCell.swift
@@ -21,7 +21,7 @@ class NotificationSettingTableViewCell: UITableViewCell {
     // "푸시 알림 설정"
     private let pushNotificationTitleLabel: UILabel = {
         let label = UILabel()
-        label.text = "푸시 알림 설정"
+        label.text = TextLiteral.MyPage.pushNotificationSetting
         label.font = EATSSUDesignFontFamily.Pretendard.regular.font(size: 16)
         label.textColor = .black
         return label
@@ -30,7 +30,7 @@ class NotificationSettingTableViewCell: UITableViewCell {
     // "매일 오전 11시에 알림을 보내드려요"
     private let dailyNotificationInfoLabel: UILabel = {
         let label = UILabel()
-        label.text = "매일 오전 11시에 알림을 보내드려요"
+        label.text = TextLiteral.MyPage.pushNotificationDescription
         label.font = EATSSUDesignFontFamily.Pretendard.regular.font(size: 12)
         label.textColor = .gray400
         return label

--- a/EATSSU/App/Sources/Presentation/MyPage/View/MyPageView/MyPageView.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/View/MyPageView/MyPageView.swift
@@ -30,7 +30,7 @@ final class MyPageView: BaseUIView {
     // 닉네임이 들어간 닉네임 변경 버튼
     var userNicknameLabel: UILabel = {
         let label = UILabel()
-        label.text = "다시 시도해주세요"
+        label.text = TextLiteral.MyPage.retry
         label.textColor = .gray700Basic
         label.font = .header1
         return label
@@ -64,7 +64,7 @@ final class MyPageView: BaseUIView {
     /// "탈퇴하기" 레이블과 탈퇴하기 아이콘
     let userWithdrawButton: UIButton = {
         let button = UIButton()
-        button.setTitle(TextLiteral.MyPage.withdraw, for: .normal)
+        button.setTitle(TextLiteral.MyPage.withdrawButton, for: .normal)
         button.setImage(EATSSUDesignAsset.Images.withdrawIcon.image, for: .normal)
         button.setTitleColor(.gray400, for: .normal)
         button.titleLabel?.font = .caption2

--- a/EATSSU/App/Sources/Presentation/MyPage/View/UserWithdrawView.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/View/UserWithdrawView.swift
@@ -116,7 +116,6 @@ final class UserWithdrawView: BaseUIView {
         completeSignOutButton.isEnabled = false
     }
 
-
     private func bindTextField() {
         NotificationCenter.default.publisher(for: UITextField.textDidChangeNotification, object: inputNickNameTextField)
             .compactMap { ($0.object as? UITextField)?.text }

--- a/EATSSU/App/Sources/Presentation/MyPage/View/UserWithdrawView.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/View/UserWithdrawView.swift
@@ -106,7 +106,7 @@ final class UserWithdrawView: BaseUIView {
         inputNickNameTextField.layer.borderWidth = 1.0
         inputNickNameTextField.layer.borderColor = UIColor.gray300.cgColor
 
-        nickNameStateGuideLabel.text = TextLiteral.inputNickName
+        nickNameStateGuideLabel.text = TextLiteral.Auth.inputNickName
         nickNameStateGuideLabel.textColor = .gray700
         nickNameStateGuideLabel.font = .caption3
 
@@ -115,6 +115,7 @@ final class UserWithdrawView: BaseUIView {
         
         completeSignOutButton.isEnabled = false
     }
+
 
     private func bindTextField() {
         NotificationCenter.default.publisher(for: UITextField.textDidChangeNotification, object: inputNickNameTextField)
@@ -157,7 +158,7 @@ final class UserWithdrawView: BaseUIView {
         case .pleaseEnter:
             // 비어있을 때 -> 회색
             nickNameStateGuideLabel.isHidden = false
-            nickNameStateGuideLabel.text = TextLiteral.inputNickName
+            nickNameStateGuideLabel.text = TextLiteral.Auth.inputNickName
             nickNameStateGuideLabel.textColor = .gray700
             inputNickNameTextField.layer.borderColor = UIColor.gray300.cgColor
             completeSignOutButton.isEnabled = false

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/CreatorViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/CreatorViewController.swift
@@ -52,7 +52,7 @@ class CreatorViewController: BaseViewController {
     override func setCustomNavigationBar() {
         // TODO: setCustomNavigationBar에 파라미터로 title 값을 받아서 네비게이션 바를 설계하도록 변경
         super.setCustomNavigationBar()
-        navigationItem.title = "만든 사람들"
+        navigationItem.title = TextLiteral.MyPage.creators
     }
     
     private func applyGradientBackground() {

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import Foundation
 import WebKit
 
 import FirebaseAnalytics
@@ -45,7 +44,7 @@ final class MyPageViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        nickName = UserInfoManager.shared.getCurrentUserInfo()?.nickname ?? ""
+        nickName = UserInfoManager.shared.getCurrentUserInfo()?.nickname ?? TextLiteral.MyPage.unknownUser
         mypageView.setUserInfo(nickname: nickName)
     }
 

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 최지우 on 2023/05/22.
 //
 
+import UIKit
 import Foundation
 import WebKit
 
@@ -14,7 +15,6 @@ import KakaoSDKTalk
 import Moya
 import Realm
 import SnapKit
-import UIKit
 
 final class MyPageViewController: BaseViewController {
     // MARK: - Properties
@@ -45,7 +45,7 @@ final class MyPageViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        nickName = UserInfoManager.shared.getCurrentUserInfo()?.nickname ?? "실패"
+        nickName = UserInfoManager.shared.getCurrentUserInfo()?.nickname ?? ""
         mypageView.setUserInfo(nickname: nickName)
     }
 
@@ -89,15 +89,15 @@ final class MyPageViewController: BaseViewController {
 
     /// 로그아웃 Alert를 스크린에 표시하는 메소드
     private func logoutShowAlert() {
-        let alert = UIAlertController(title: "로그아웃",
-                                      message: "정말 로그아웃 하시겠습니까?",
+        let alert = UIAlertController(title: TextLiteral.MyPage.logout,
+                                      message: TextLiteral.MyPage.askLogout,
                                       preferredStyle: UIAlertController.Style.alert)
 
-        let cancelAction = UIAlertAction(title: "취소하기",
+        let cancelAction = UIAlertAction(title: TextLiteral.Common.cancelDark,
                                          style: .default,
                                          handler: nil)
 
-        let fixAction = UIAlertAction(title: "로그아웃",
+        let fixAction = UIAlertAction(title: TextLiteral.MyPage.logout,
                                       style: .default,
                                       handler: { _ in
                                           RealmService.shared.resetDB()
@@ -207,8 +207,8 @@ extension MyPageViewController: UITableViewDelegate {
                         UIApplication.shared.open(kakaoChannelLink)
                     } else {
                         self?.showAlertController(
-                            title: "다시 시도하세요",
-                            message: "에러가 발생했습니다",
+                            title: TextLiteral.Common.retry,
+                            message: TextLiteral.Common.errorOccured,
                             style: .default
                         )
                     }
@@ -266,8 +266,8 @@ extension MyPageViewController: UITableViewDelegate {
                     let formattedDate = dateFormatter.string(from: Date())
                     
                     let message = newState
-                        ? "EAT-SSU 수신 동의 (\(formattedDate))"
-                        : "EAT-SSU 수신 거절 (\(formattedDate))"
+                        ? TextLiteral.MyPage.agreeNoti(date: formattedDate)
+                        : TextLiteral.MyPage.disagreeNoti(date: formattedDate)
                     
                     self.showToast(message: message, type: .info)
                 }
@@ -278,7 +278,7 @@ extension MyPageViewController: UITableViewDelegate {
                     case .permissionDenied:
                         self.showNotificationPermissionAlert()
                     case .unknown:
-                        self.showToast(message: "알림 설정 중 오류가 발생했습니다.", type: .danger)
+                        self.showToast(message: TextLiteral.MyPage.notiSettingError, type: .danger)
                     }
                 }
             }
@@ -295,11 +295,11 @@ extension MyPageViewController: UITableViewDelegate {
             preferredStyle: .alert
         )
         
-        let settingsAction = UIAlertAction(title: "설정으로 이동", style: .default) { _ in
+        let settingsAction = UIAlertAction(title: TextLiteral.Common.moveToSetting, style: .default) { _ in
             NotificationManager.shared.openNotificationSettings() 
         }
         
-        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        let cancelAction = UIAlertAction(title: TextLiteral.Common.cancel, style: .cancel)
         
         alert.addAction(settingsAction)
         alert.addAction(cancelAction)

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
@@ -85,13 +85,13 @@ final class MyReviewViewController: BaseViewController {
 
     private func showFixOrDeleteAlert(reviewID: Int, reviewItem: MyReviewListItem) {
         let alert = UIAlertController(
-            title: "리뷰 수정 혹은 삭제",
-            message: "작성하신 리뷰를 수정 또는 삭제하시겠습니까?",
+            title: TextLiteral.MyPage.fixOrDeleteReview,
+            message: TextLiteral.MyPage.askFixOrDeleteReview,
             preferredStyle: UIAlertController.Style.actionSheet
         )
 
         let fixAction = UIAlertAction(
-            title: "수정하기",
+            title: TextLiteral.Common.fix,
             style: .default,
             handler: { _ in
                 let setRateViewController = SetRateViewController()
@@ -116,7 +116,7 @@ final class MyReviewViewController: BaseViewController {
         )
 
         let deleteAction = UIAlertAction(
-            title: "삭제하기",
+            title: TextLiteral.Common.delete,
             style: .default,
             handler: { _ in
                 self.deleteReview(reviewID: reviewID)
@@ -124,7 +124,7 @@ final class MyReviewViewController: BaseViewController {
         )
 
         let cancelAction = UIAlertAction(
-            title: "취소하기",
+            title: TextLiteral.Common.cancelDark,
             style: .cancel,
             handler: nil
         )
@@ -137,7 +137,7 @@ final class MyReviewViewController: BaseViewController {
     
     private func navigateToLogin() {
         let loginVC = LoginViewController()
-        loginVC.toastMessage = "세션이 만료되었습니다. 다시 로그인해주세요."
+        loginVC.toastMessage = TextLiteral.Common.sessionExpired
         loginVC.toastType = .info
         
         DispatchQueue.main.async {
@@ -226,10 +226,10 @@ extension MyReviewViewController {
     
     func deleteReview(reviewID: Int) {
         showCustomDialog(
-            title: "리뷰 삭제하기",
-            message: "해당 리뷰를 삭제할까요?",
-            cancelButtonTitle: "취소하기",
-            confirmButtonTitle: "삭제하기"
+            title: TextLiteral.MyPage.deleteMyReview,
+            message: TextLiteral.MyPage.askDeleteMyReview,
+            cancelButtonTitle: TextLiteral.Common.cancelDark,
+            confirmButtonTitle: TextLiteral.Common.delete
         ) { [weak self] in
             guard let self = self else { return }
             
@@ -241,7 +241,7 @@ extension MyReviewViewController {
                 switch result {
                 case .success:
                     self.getMyReview()
-                    self.showToast(message: "리뷰가 성공적으로 삭제되었습니다.")
+                    self.showToast(message: TextLiteral.MyPage.deleteMyReviewSuccess)
                 case .failure(let error):
                     print("리뷰 삭제 실패: \(error.localizedDescription)")
                     RealmService.shared.resetDB()

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/UserWithdrawViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/UserWithdrawViewController.swift
@@ -78,7 +78,7 @@ final class UserWithdrawViewController: BaseViewController {
 
     override func setCustomNavigationBar() {
         super.setCustomNavigationBar()
-        navigationItem.title = "회원탈퇴"
+        navigationItem.title = TextLiteral.MyPage.withdraw
     }
 
     override func setButtonEvent() {
@@ -148,7 +148,7 @@ extension UserWithdrawViewController {
                 if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                    let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow })
                 {
-                    loginViewController.toastMessage = "탈퇴 처리가 완료되었습니다."
+                    loginViewController.toastMessage = TextLiteral.Common.withdrawComplete
                     keyWindow.replaceRootViewController(UINavigationController(rootViewController: loginViewController))
                 }
                 

--- a/EATSSU/App/Sources/Presentation/Review/View/RateReview/SetRateView.swift
+++ b/EATSSU/App/Sources/Presentation/Review/View/RateReview/SetRateView.swift
@@ -65,7 +65,7 @@ final class SetRateView: UIView {
     
     let maximumWordLabel: UILabel = {
         let label = UILabel()
-        label.text = "0 / 300"
+        label.text = TextLiteral.Review.characterCount(current: 0, max: 300)
         label.font = .caption3
         label.textColor = EATSSUDesignAsset.Color.GrayScale.gray500.color
         return label

--- a/EATSSU/App/Sources/Presentation/Review/View/RateReview/SetRateView.swift
+++ b/EATSSU/App/Sources/Presentation/Review/View/RateReview/SetRateView.swift
@@ -27,7 +27,7 @@ final class SetRateView: UIView {
 
     let menuLabel: UILabel = {
         let label = UILabel()
-        label.text = "오늘의 식사는 어떠셨나요?"
+        label.text = TextLiteral.Review.rateTodayMeal
         label.font = .subtitle1
         label.textColor = .black
         return label
@@ -37,7 +37,7 @@ final class SetRateView: UIView {
 
     let detailLabel: UILabel = {
         let label = UILabel()
-        label.text = "추천하고 싶은 메뉴가 있나요?"
+        label.text = TextLiteral.Review.recommendMenu
         label.font = .subtitle1
         label.textColor = .black
         return label
@@ -90,7 +90,7 @@ final class SetRateView: UIView {
     
     let imageCountLabel: UILabel = {
         let label = UILabel()
-        label.text = "사진 0/1"
+        label.text = TextLiteral.Review.photoCount
         label.font = .caption3
         label.textColor = EATSSUDesignAsset.Color.GrayScale.gray400.color
         label.textAlignment = .center
@@ -117,7 +117,7 @@ final class SetRateView: UIView {
     
     let deleteMethodLabel: UILabel = {
         let label = UILabel()
-        label.text = "사진 클릭 시, 삭제됩니다"
+        label.text = TextLiteral.Review.deletePhoto
         label.font = .caption3
         label.textColor = EATSSUDesignAsset.Color.GrayScale.gray500.color
         return label
@@ -133,7 +133,7 @@ final class SetRateView: UIView {
     
     let nextButton: MainButton = {
         let button = MainButton()
-        button.title = "리뷰 남기기"
+        button.title = TextLiteral.Review.leaveReview
         return button
     }()
     
@@ -268,7 +268,7 @@ final class SetRateView: UIView {
     // MARK: - Public Methods
 
     func setInitialTextViewState() {
-        userReviewTextView.text = "메뉴에 대한 상세한 리뷰를 작성해주세요"
+        userReviewTextView.text = TextLiteral.Review.inputDetailReview
         userReviewTextView.textColor = EATSSUDesignAsset.Color.GrayScale.gray500.color
         userReviewTextView.font = .body2
     }
@@ -277,6 +277,6 @@ final class SetRateView: UIView {
         userReviewImageView.image = image
         userReviewImageView.isHidden = isHidden
         closeButton.isHidden = isHidden || (image == nil)
-        imageCountLabel.text = "사진 \(count)/1"
+        imageCountLabel.text = TextLiteral.Review.photoCount(count: count)
     }
 }

--- a/EATSSU/App/Sources/Presentation/Review/View/ReportView/ReportView.swift
+++ b/EATSSU/App/Sources/Presentation/Review/View/ReportView/ReportView.swift
@@ -17,7 +17,7 @@ final class ReportView: BaseUIView {
     /// "리뷰 신고 사유를 알려주세요" 레이블
     private let reviewReportReasonLabel: UILabel = {
         let label = UILabel()
-        label.text = "리뷰 신고 사유를 알려주세요"
+        label.text = TextLiteral.Review.reportReason
         label.font = EATSSUDesignFontFamily.Pretendard.bold.font(size: 18)
         label.textColor = .black
         return label
@@ -26,29 +26,29 @@ final class ReportView: BaseUIView {
     /// "하나의 리뷰에 대해 24시간 내 한 번만 신고 가능합니다." 레이블
     private let singleReportPerDayLabel: UILabel = {
         let label = UILabel()
-        label.text = "하나의 리뷰에 대해 24시간 내 한 번만 신고 가능합니다."
+        label.text = TextLiteral.Review.reportGuide
         label.font = EATSSUDesignFontFamily.Pretendard.regular.font(size: 12)
         label.textColor = .gray600
         return label
     }()
 
     /// "메뉴와 관련없는 내용" 버튼
-    let unrelatedToMenuButton = ESReportButton(title: "메뉴와 관련없는 내용")
+    let unrelatedToMenuButton = ESReportButton(title: TextLiteral.Review.unrelatedMenu)
 
     /// "음란성, 욕설 등 부적절한 내용" 버튼
-    let inappropriateContentButton = ESReportButton(title: "음란성, 욕설 등 부적절한 내용")
+    let inappropriateContentButton = ESReportButton(title: TextLiteral.Review.inappropriateContent)
 
     /// " 부적절한 홍보 또는 광고" 버튼
-    let inappropriatePromotionButton = ESReportButton(title: "부적절한 홍보 또는 광고")
+    let inappropriatePromotionButton = ESReportButton(title: TextLiteral.Review.inappropriateAd)
 
     /// "리뷰 작성 취지에 맞지 않는 내용 (복사글 등)" 버튼
-    let offTopicContentButton = ESReportButton(title: "리뷰 작성 취지에 맞지 않는 내용 (복사글 등)")
+    let offTopicContentButton = ESReportButton(title: TextLiteral.Review.notReviewFormat)
 
     /// "저작권 도용 의심 (사진 등)" 버튼
-    let copyrightInfringementButton = ESReportButton(title: "저작권 도용 의심 (사진 등)")
+    let copyrightInfringementButton = ESReportButton(title: TextLiteral.Review.copyright)
 
     /// "기타 (하단 내용 작성)" 버튼
-    let otherReasonButton = ESReportButton(title: "기타 (하단 내용 작성)")
+    let otherReasonButton = ESReportButton(title: TextLiteral.Review.etc)
 
     /// "리뷰 신고 사유를 작성해 주세요" 텍스트필드
     var reviewReportReasonTextView: UITextView = {
@@ -59,7 +59,7 @@ final class ReportView: BaseUIView {
         textView.layer.borderWidth = 1
         textView.layer.borderColor = UIColor.gray200.cgColor
         textView.textContainerInset = UIEdgeInsets(top: 16.0, left: 16.0, bottom: 16.0, right: 16.0)
-        textView.text = "리뷰 신고 사유를 작성해 주세요"
+        textView.text = TextLiteral.Review.inputReportReason
         textView.textColor = EATSSUDesignAsset.Color.GrayScale.gray400.color
         textView.isEditable = false
         return textView
@@ -81,7 +81,7 @@ final class ReportView: BaseUIView {
 
     func disableTextView() {
         reviewReportReasonTextView.isEditable = false
-        reviewReportReasonTextView.text = "리뷰 신고 사유를 작성해 주세요"
+        reviewReportReasonTextView.text = TextLiteral.Review.inputReportReason
         reviewReportReasonTextView.textColor = EATSSUDesignAsset.Color.GrayScale.gray400.color
         reviewReportReasonTextView.resignFirstResponder()
         characterCountLabel.text = "0 / 300"
@@ -187,7 +187,7 @@ extension ReportView: UITextViewDelegate {
 
     func textViewDidEndEditing(_ textView: UITextView) {
         if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            textView.text = "리뷰 신고 사유를 작성해 주세요"
+            textView.text = TextLiteral.Review.inputReportReason
             textView.textColor = EATSSUDesignAsset.Color.GrayScale.gray400.color
             characterCountLabel.text = "0 / 300"
         } else {

--- a/EATSSU/App/Sources/Presentation/Review/View/ReportView/ReportView.swift
+++ b/EATSSU/App/Sources/Presentation/Review/View/ReportView/ReportView.swift
@@ -67,7 +67,7 @@ final class ReportView: BaseUIView {
 
     var characterCountLabel: UILabel = {
         let label = UILabel()
-        label.text = "0 / 300"
+        label.text = TextLiteral.Review.characterCount(current: 0, max: 300)
         label.font = EATSSUDesignFontFamily.Pretendard.regular.font(size: 12)
         label.textColor = .gray400
         return label
@@ -84,7 +84,7 @@ final class ReportView: BaseUIView {
         reviewReportReasonTextView.text = TextLiteral.Review.inputReportReason
         reviewReportReasonTextView.textColor = EATSSUDesignAsset.Color.GrayScale.gray400.color
         reviewReportReasonTextView.resignFirstResponder()
-        characterCountLabel.text = "0 / 300"
+        characterCountLabel.text = TextLiteral.Review.characterCount(current: 0, max: 300)
     }
 
     override func configureUI() {
@@ -174,7 +174,7 @@ extension ReportView: UITextViewDelegate {
         if newLength > 300 { return false }
         
         let textToDisplay = currentText.replacingCharacters(in: stringRange, with: text)
-        characterCountLabel.text = "\(textToDisplay.count) / 300"
+        characterCountLabel.text = TextLiteral.Review.characterCount(current: textToDisplay.count, max: 300)
         return true
     }
     
@@ -189,9 +189,9 @@ extension ReportView: UITextViewDelegate {
         if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             textView.text = TextLiteral.Review.inputReportReason
             textView.textColor = EATSSUDesignAsset.Color.GrayScale.gray400.color
-            characterCountLabel.text = "0 / 300"
+            characterCountLabel.text = TextLiteral.Review.characterCount(current: 0, max: 300)
         } else {
-            characterCountLabel.text = "\(textView.text.count) / 300"
+            characterCountLabel.text = TextLiteral.Review.characterCount(current: textView.text.count, max: 300)
         }
     }
 }

--- a/EATSSU/App/Sources/Presentation/Review/View/SeeReview/ReviewDividerCell.swift
+++ b/EATSSU/App/Sources/Presentation/Review/View/SeeReview/ReviewDividerCell.swift
@@ -28,7 +28,6 @@ final class ReviewDividerCell: UITableViewCell {
     /// 리뷰 개수 표시 레이블
     private let label: UILabel = {
         let label = UILabel()
-        label.text = "리뷰 15"
         label.font = EATSSUDesignFontFamily.Pretendard.bold.font(size: 16)
         label.textColor = .black
         return label
@@ -71,7 +70,7 @@ final class ReviewDividerCell: UITableViewCell {
     /// 리뷰 개수로 셀 구성
     /// - Parameter reviewCount: 표시할 리뷰 개수
     func configure(reviewCount: Int) {
-        let text = "리뷰 \(reviewCount)"
+        let text = TextLiteral.Review.reviewCount(reviewCount)
         let attributed = NSMutableAttributedString(string: text)
         let range = (text as NSString).range(of: "\(reviewCount)")
         attributed.addAttribute(

--- a/EATSSU/App/Sources/Presentation/Review/View/SeeReview/ReviewEmptyViewCell.swift
+++ b/EATSSU/App/Sources/Presentation/Review/View/SeeReview/ReviewEmptyViewCell.swift
@@ -29,7 +29,7 @@ final class ReviewEmptyViewCell: UITableViewCell {
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.font = .subtitle2
-        label.text = "아직 작성된 리뷰가 없어요!"
+        label.text = TextLiteral.Review.noReview
         label.textColor = EATSSUDesignAsset.Color.GrayScale.gray600.color
         label.textAlignment = .center
         return label
@@ -38,7 +38,7 @@ final class ReviewEmptyViewCell: UITableViewCell {
     /// 설명 레이블
     private lazy var descriptionLabel: UILabel = {
         let label = UILabel()
-        label.text = "메뉴에 가장 먼저 리뷰를 남겨주세요!"
+        label.text = TextLiteral.Review.beFirstReviewer
         label.font = .caption2
         label.textColor = EATSSUDesignAsset.Color.GrayScale.gray600.color
         label.textAlignment = .center
@@ -94,17 +94,17 @@ final class ReviewEmptyViewCell: UITableViewCell {
     func configure(isTokenExist: Bool) {
         if isTokenExist {
             noReviewImageView.image = EATSSUDesignAsset.Images.noReview.image
-            titleLabel.text = "아직 작성된 리뷰가 없어요"
-            descriptionLabel.text = "메뉴에 가장 먼저 리뷰를 남겨주세요!"
+            titleLabel.text = TextLiteral.Review.noWrittenReview
+            descriptionLabel.text = TextLiteral.Review.beFirstReviewer
         } else {
-            titleLabel.text = "로그인이 필요합니다"
-            descriptionLabel.text = "로그인 후 리뷰를 확인하세요"
+            titleLabel.text = TextLiteral.Review.needLogin
+            descriptionLabel.text = TextLiteral.Review.checkReviewAfterLogin
         }
     }
     
     /// 마이페이지용 빈 상태 구성
     func configureForMyReview() {
-        titleLabel.text = "아직 작성한 리뷰가 없어요"
-        descriptionLabel.text = "첫 리뷰를 남겨 주세요!"
+        titleLabel.text = TextLiteral.Review.noWrittenReview
+        descriptionLabel.text = TextLiteral.Review.writeFirstReview
     }
 }

--- a/EATSSU/App/Sources/Presentation/Review/View/SeeReview/ReviewRateViewCell.swift
+++ b/EATSSU/App/Sources/Presentation/Review/View/SeeReview/ReviewRateViewCell.swift
@@ -36,7 +36,7 @@ final class ReviewRateViewCell: UITableViewCell {
     /// 메뉴 이름 레이블
     var menuLabel: UILabel = {
         let label = UILabel()
-        label.text = "김치볶음밥 & 계란국"
+        label.text = ""
         label.font = .body1
         label.textColor = .black
         label.numberOfLines = 0
@@ -54,7 +54,7 @@ final class ReviewRateViewCell: UITableViewCell {
     /// "오늘의 메뉴" 타이틀 레이블
     private let menuTitleLabel: UILabel = {
         let label = UILabel()
-        label.text = "오늘의 메뉴"
+        label.text = TextLiteral.Review.todayMenu
         label.font = .subtitle2
         label.textColor = .black
         return label
@@ -96,11 +96,11 @@ final class ReviewRateViewCell: UITableViewCell {
     // MARK: - UI Components - Rating Chart
     
     /// 별점별 레이블들
-    private let fivePointLabel = ReviewRateViewCell.makePointLabel("5점")
-    private let fourPointLabel = ReviewRateViewCell.makePointLabel("4점")
-    private let threePointLabel = ReviewRateViewCell.makePointLabel("3점")
-    private let twoPointLabel = ReviewRateViewCell.makePointLabel("2점")
-    private let onePointLabel = ReviewRateViewCell.makePointLabel("1점")
+    private let fivePointLabel = ReviewRateViewCell.makePointLabel(TextLiteral.Review.fiveStars)
+    private let fourPointLabel = ReviewRateViewCell.makePointLabel(TextLiteral.Review.fourStars)
+    private let threePointLabel = ReviewRateViewCell.makePointLabel(TextLiteral.Review.threeStars)
+    private let twoPointLabel = ReviewRateViewCell.makePointLabel(TextLiteral.Review.twoStars)
+    private let onePointLabel = ReviewRateViewCell.makePointLabel(TextLiteral.Review.oneStar)
     
     /// 차트 바 컨테이너들
     var oneChartBar: UIView!

--- a/EATSSU/App/Sources/Presentation/Review/View/SeeReview/ReviewTableCell.swift
+++ b/EATSSU/App/Sources/Presentation/Review/View/SeeReview/ReviewTableCell.swift
@@ -125,7 +125,7 @@ final class ReviewTableCell: UITableViewCell {
         textView.isScrollEnabled = false
         textView.backgroundColor = .systemBackground
         textView.font = .body1
-        textView.text = "여기 계란국 맛집임... 김치볶음밥에 계란후라이 없어서 아쉽 다음에 또 먹어야지"
+        textView.text = ""
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
         return textView

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/ReportViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/ReportViewController.swift
@@ -14,6 +14,16 @@ import FirebaseAnalytics
 import EATSSUDesign
 
 final class ReportViewController: BaseViewController {
+    
+    private enum ReportType: String {
+        case noAssociateContent = "NO_ASSOCIATE_CONTENT"
+        case improperContent = "IMPROPER_CONTENT"
+        case improperAdvertisement = "IMPROPER_ADVERTISEMENT"
+        case copy = "COPY"
+        case copyright = "COPYRIGHT"
+        case extra = "EXTRA"
+    }
+
     // MARK: - Properties
     
     // View Properties
@@ -273,22 +283,22 @@ extension ReportViewController {
         
         switch content {
         case TextLiteral.Review.unrelatedMenu:
-            reportType = "NO_ASSOCIATE_CONTENT"
+            reportType = ReportType.noAssociateContent.rawValue
             reportContent = content
         case TextLiteral.Review.inappropriateContent:
-            reportType = "IMPROPER_CONTENT"
+            reportType = ReportType.improperContent.rawValue
             reportContent = content
         case TextLiteral.Review.inappropriateAd:
-            reportType = "IMPROPER_ADVERTISEMENT"
+            reportType = ReportType.improperAdvertisement.rawValue
             reportContent = content
         case TextLiteral.Review.notReviewFormat:
-            reportType = "COPY"
+            reportType = ReportType.copy.rawValue
             reportContent = content
         case TextLiteral.Review.copyright:
-            reportType = "COPYRIGHT"
+            reportType = ReportType.copyright.rawValue
             reportContent = content
         case TextLiteral.Review.etc:
-            reportType = "EXTRA"
+            reportType = ReportType.extra.rawValue
             reportContent = reportView.reviewReportReasonTextView.text
         default:
             reportType = ""

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/ReportViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/ReportViewController.swift
@@ -20,7 +20,7 @@ final class ReportViewController: BaseViewController {
     private let reportView = ReportView()
     private let scrollView = UIScrollView()
     
-    private let sendToEATSSUButton = ESButton(size: .big, title: "EAT SSU 팀에게 보내기")
+    private let sendToEATSSUButton = ESButton(size: .big, title: TextLiteral.Review.sendToTeam)
     
     // Variable Properties
     private var isChecked = false
@@ -122,7 +122,7 @@ final class ReportViewController: BaseViewController {
     
     override func setCustomNavigationBar() {
         super.setCustomNavigationBar()
-        title = "신고하기"
+        title = TextLiteral.Review.report
         
         let navBarApperance = UINavigationBarAppearance()
         navBarApperance.configureWithOpaqueBackground()
@@ -170,7 +170,7 @@ final class ReportViewController: BaseViewController {
         if isReasonSelected {
             postReport(reviewID: reviewID, content: contentArray[status] ?? "")
         } else {
-            showToast(message: "사유를 선택해주세요!", type: .info)
+            showToast(message: TextLiteral.Review.selectReason, type: .info)
         }
     }
     
@@ -259,7 +259,7 @@ final class ReportViewController: BaseViewController {
         self.navigationController?.popViewController(animated: true)
         
         navigationController.transitionCoordinator?.animate(alongsideTransition: nil, completion: { _ in
-            previousVC.showToast(message: "신고가 성공적으로 접수되었어요!", type: .success)
+            previousVC.showToast(message: TextLiteral.Review.reportSuccess, type: .success)
         })
     }
 }
@@ -272,22 +272,22 @@ extension ReportViewController {
         var reportContent = String()
         
         switch content {
-        case "메뉴와 관련없는 내용":
+        case TextLiteral.Review.unrelatedMenu:
             reportType = "NO_ASSOCIATE_CONTENT"
             reportContent = content
-        case "음란성, 욕설 등 부적절한 내용":
+        case TextLiteral.Review.inappropriateContent:
             reportType = "IMPROPER_CONTENT"
             reportContent = content
-        case "부적절한 홍보 또는 광고":
+        case TextLiteral.Review.inappropriateAd:
             reportType = "IMPROPER_ADVERTISEMENT"
             reportContent = content
-        case "리뷰 작성 취지에 맞지 않는 내용 (복사글 등)":
+        case TextLiteral.Review.notReviewFormat:
             reportType = "COPY"
             reportContent = content
-        case "저작권 도용 의심 (사진 등)":
+        case TextLiteral.Review.copyright:
             reportType = "COPYRIGHT"
             reportContent = content
-        case "기타 (하단 내용 작성)":
+        case TextLiteral.Review.etc:
             reportType = "EXTRA"
             reportContent = reportView.reviewReportReasonTextView.text
         default:
@@ -310,7 +310,7 @@ extension ReportViewController {
                 
             case .failure(let error):
                 print("신고 실패: \(error.localizedDescription)")
-                self?.showToast(message: "잠시 후 다시 시도해주세요.", type: .danger)
+                self?.showToast(message: TextLiteral.Common.tryAgain, type: .danger)
             }
         }
     }

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/ReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/ReviewViewController.swift
@@ -86,7 +86,7 @@ final class ReviewViewController: BaseViewController {
     /// 리뷰 작성 버튼
     private let reviewTabBarView: MainButton = {
         let button = MainButton()
-        button.title = "리뷰 작성하기"
+        button.title = TextLiteral.Review.writeReview
         return button
     }()
     
@@ -113,7 +113,7 @@ final class ReviewViewController: BaseViewController {
         super.viewDidAppear(animated)
         
         if shouldShowSuccessToast {
-            showToast(message: "리뷰가 성공적으로 등록되었습니다.")
+            showToast(message: TextLiteral.Review.registerReviewSuccess)
             shouldShowSuccessToast = false
         }
     }
@@ -161,7 +161,7 @@ final class ReviewViewController: BaseViewController {
     
     override func setCustomNavigationBar() {
         super.setCustomNavigationBar()
-        navigationItem.title = "리뷰"
+        navigationItem.title = TextLiteral.Review.review
     }
     
     override func setButtonEvent() {
@@ -240,10 +240,10 @@ final class ReviewViewController: BaseViewController {
             return
         }
         
-        let title = "리뷰 삭제"
-        let message = "해당 리뷰를 삭제할까요?"
-        let confirmButtonTitle = "삭제하기"
-        let cancelButtonTitle = "취소하기"
+        let title = TextLiteral.Review.deleteReview
+        let message = TextLiteral.Review.askDeleteReview
+        let confirmButtonTitle = TextLiteral.Common.delete
+        let cancelButtonTitle = TextLiteral.Common.cancelDark
         
         self.showCustomDialog(
             title: title,
@@ -260,10 +260,10 @@ final class ReviewViewController: BaseViewController {
     /// - Parameter reviewID: 신고할 리뷰 ID
     private func showReportAlert(reviewID: Int) {
         showCustomDialog(
-            title: "리뷰 신고하기",
-            message: "해당 리뷰를 신고하시겠습니까?",
-            cancelButtonTitle: "취소하기",
-            confirmButtonTitle: "신고하기"
+            title: TextLiteral.Review.reportReview,
+            message: TextLiteral.Review.askReportReview,
+            cancelButtonTitle: TextLiteral.Common.cancelDark,
+            confirmButtonTitle: TextLiteral.Review.report
         ) { [weak self] in
             let reportViewController = ReportViewController()
             reportViewController.bindData(reviewID: reviewID)
@@ -318,8 +318,8 @@ final class ReviewViewController: BaseViewController {
             }
         } else {
             showAlertControllerWithCancel(
-                title: "로그인이 필요한 서비스입니다",
-                message: "로그인 하시겠습니까?",
+                title: TextLiteral.Common.needLogin,
+                message: TextLiteral.Common.askLogin,
                 confirmStyle: .default
             ) {
                 self.pushToLoginVC()
@@ -701,11 +701,11 @@ extension ReviewViewController {
                     self.getValidMenusForReview()
                 }
                 self.getReviewList(type: self.type, menuId: self.menuID)
-                self.showToast(message: "리뷰가 성공적으로 삭제되었습니다.")
+                self.showToast(message: TextLiteral.Review.deleteReviewSuccess)
                 
             case let .failure(error):
                 print("❌ Delete Review Error: \(error.localizedDescription)")
-                self.showToast(message: "리뷰 삭제에 실패했습니다.")
+                self.showToast(message: TextLiteral.Review.deleteReviewFail)
             }
         }
     }

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
@@ -112,7 +112,7 @@ final class SetRateViewController: BaseViewController, UINavigationControllerDel
     
     override func setCustomNavigationBar() {
         super.setCustomNavigationBar()
-        navigationItem.title = reviewId != nil ? "리뷰 수정하기" : "리뷰 남기기"
+        navigationItem.title = reviewId != nil ? TextLiteral.Review.fixReview : TextLiteral.Review.leaveReview
 
         navigationItem.hidesBackButton = true
         navigationItem.leftBarButtonItem = nil
@@ -186,7 +186,7 @@ final class SetRateViewController: BaseViewController, UINavigationControllerDel
         self.likedStates = likedStates
         self.reviewType = .fixed
         
-        setRateView.menuLabel.text = "\(menuNames.first ?? "") 을/를 추천하시겠어요?"
+        setRateView.menuLabel.text = TextLiteral.Review.recommendMenu(menu: menuNames.first ?? "")
         setRateView.menuTableView.reloadData()
         view.setNeedsLayout()
     }
@@ -196,10 +196,10 @@ final class SetRateViewController: BaseViewController, UINavigationControllerDel
         self.reviewId = reviewId
         self.likedStates = Array(repeating: false, count: list.count)
         
-        setRateView.menuLabel.text = "\(list[0]) 을/를 추천하시겠어요?"
+        setRateView.menuLabel.text = TextLiteral.Review.recommendMenu(menu: list[0])
         setRateView.selectImageButton.isHidden = true
         setRateView.deleteMethodLabel.isHidden = true
-        setRateView.nextButton.setTitle("리뷰 수정 완료하기", for: .normal)
+        setRateView.nextButton.setTitle(TextLiteral.Review.fixReviewComplete, for: .normal)
     }
 
     func dataBindForFix(
@@ -227,8 +227,8 @@ final class SetRateViewController: BaseViewController, UINavigationControllerDel
         }
 
         setRateView.menuLabel.text = list.count == 1
-            ? "\(list[0]) 를/을 추천하시겠어요?"
-            : "메뉴를 추천하시겠어요?"
+            ? TextLiteral.Review.recommendMenuWithParticle(menu: list[0])
+            : TextLiteral.Review.recommendMenuTitle
 
         if let rating = rating {
             setRateView.rateView.currentStar = rating
@@ -248,7 +248,7 @@ final class SetRateViewController: BaseViewController, UINavigationControllerDel
             setRateView.updateImageViewState(image: nil, count: 0, isHidden: true)
         }
    
-        setRateView.nextButton.setTitle("완료하기", for: .normal)
+        setRateView.nextButton.setTitle(TextLiteral.Review.complete, for: .normal)
         setRateView.menuTableView.reloadData()
         view.setNeedsLayout()
     }
@@ -321,7 +321,7 @@ final class SetRateViewController: BaseViewController, UINavigationControllerDel
     @objc
     func tappedNextButton() {
         guard setRateView.rateView.currentStar != 0 else {
-            showToast(message: "별점을 입력해주세요!", type: .info)
+            showToast(message: TextLiteral.Review.inputRating, type: .info)
             return
         }
 
@@ -387,7 +387,7 @@ extension SetRateViewController {
                     
                 case .failure(let error):
                     print("❌ Error fetching valid menus: \(error)")
-                    self.showToast(message: "메뉴 목록 조회에 실패했습니다.")
+                    self.showToast(message: TextLiteral.Review.loadMenuListFail)
                 }
             }
         }
@@ -395,7 +395,7 @@ extension SetRateViewController {
     
     private func sendFixReview() {
         guard let reviewId = reviewId else {
-            showToast(message: "수정할 리뷰 정보가 없습니다.")
+            showToast(message: TextLiteral.Review.noReviewInfoForFix)
             return
         }
 
@@ -419,14 +419,14 @@ extension SetRateViewController {
                 
                 await MainActor.run {
                     self.isReviewSubmitted = true
-                    self.showToast(message: "리뷰가 성공적으로 수정되었습니다.")
+                    self.showToast(message: TextLiteral.Review.fixReviewSuccess)
                     self.moveToReviewVC()
                 }
                 
             } catch {
                 await MainActor.run {
                     print("❌ Review 수정 업로드 실패: \(error)")
-                    self.showToast(message: "리뷰 수정에 실패했습니다.")
+                    self.showToast(message: TextLiteral.Review.fixReviewFail)
                 }
             }
         }
@@ -434,7 +434,7 @@ extension SetRateViewController {
     
     private func sendMealReview() {
         guard let mealId = mealID else {
-            showToast(message: "식단 정보가 없습니다.")
+            showToast(message: TextLiteral.Review.noMealInfo)
             return
         }
 
@@ -468,8 +468,7 @@ extension SetRateViewController {
 
             } catch {
                 await MainActor.run {
-                    print("❌ Meal 리뷰 업로드 실패: \(error)")
-                    self.showToast(message: "리뷰 업로드에 실패했습니다.")
+                    self.showToast(message: TextLiteral.Review.uploadReviewFail)
                 }
             }
         }
@@ -477,7 +476,7 @@ extension SetRateViewController {
     
     private func sendMenuReview() {
         guard let menuId = menuID ?? validMenuIDList.first else {
-            showToast(message: "메뉴 정보가 없습니다.")
+            showToast(message: TextLiteral.Review.noMenuInfo)
             return
         }
 
@@ -514,7 +513,7 @@ extension SetRateViewController {
             } catch {
                 await MainActor.run {
                     print("❌ Menu 리뷰 업로드 실패: \(error)")
-                    self.showToast(message: "리뷰 업로드에 실패했습니다.")
+                    self.showToast(message: TextLiteral.Review.uploadReviewFail)
                 }
             }
         }
@@ -624,7 +623,7 @@ extension SetRateViewController: UITableViewDataSource, UITableViewDelegate {
 extension SetRateViewController: UITextViewDelegate {
 
     private var placeholderText: String {
-        return "메뉴에 대한 상세한 리뷰를 작성해주세요"
+        return TextLiteral.Review.inputDetailReview
     }
     
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
@@ -674,10 +673,10 @@ extension SetRateViewController: UIImagePickerControllerDelegate, UIGestureRecog
         let isReviewStarted: Bool = setRateView.rateView.currentStar > 0 || textHasContent
         
         if reviewId == nil, isReviewStarted {
-            let title = "나가시겠어요?"
-            let message = "지금 나가면 작성한 내용이 저장되지 않습니다."
-            let confirmButtonTitle = "나가기"
-            let cancelButtonTitle = "계속 작성"
+            let title = TextLiteral.Review.askLeave
+            let message = TextLiteral.Review.leaveWarning
+            let confirmButtonTitle = TextLiteral.Review.leave
+            let cancelButtonTitle = TextLiteral.Review.continueWriting
             
             self.showCustomDialog(
                 title: title,

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
@@ -186,7 +186,7 @@ final class SetRateViewController: BaseViewController, UINavigationControllerDel
         self.likedStates = likedStates
         self.reviewType = .fixed
         
-        setRateView.menuLabel.text = TextLiteral.Review.recommendMenu(menu: menuNames.first ?? "")
+        setRateView.menuLabel.text = TextLiteral.Review.recommendMenu(name: menuNames.first ?? "")
         setRateView.menuTableView.reloadData()
         view.setNeedsLayout()
     }
@@ -196,7 +196,7 @@ final class SetRateViewController: BaseViewController, UINavigationControllerDel
         self.reviewId = reviewId
         self.likedStates = Array(repeating: false, count: list.count)
         
-        setRateView.menuLabel.text = TextLiteral.Review.recommendMenu(menu: list[0])
+        setRateView.menuLabel.text = TextLiteral.Review.recommendMenu(name: list[0])
         setRateView.selectImageButton.isHidden = true
         setRateView.deleteMethodLabel.isHidden = true
         setRateView.nextButton.setTitle(TextLiteral.Review.fixReviewComplete, for: .normal)
@@ -227,7 +227,7 @@ final class SetRateViewController: BaseViewController, UINavigationControllerDel
         }
 
         setRateView.menuLabel.text = list.count == 1
-            ? TextLiteral.Review.recommendMenuWithParticle(menu: list[0])
+            ? TextLiteral.Review.recommendMenu(name: list[0])
             : TextLiteral.Review.recommendMenuTitle
 
         if let rating = rating {
@@ -238,7 +238,7 @@ final class SetRateViewController: BaseViewController, UINavigationControllerDel
         if let content = content, !content.isEmpty {
             setRateView.userReviewTextView.text = content
             setRateView.userReviewTextView.textColor = .black
-            setRateView.maximumWordLabel.text = "\(content.count) / 300"
+            setRateView.maximumWordLabel.text = TextLiteral.Review.characterCount(current: content.count, max: 300)
         }
 
         if let firstImageUrl = imageUrls.first, !firstImageUrl.isEmpty {
@@ -468,6 +468,7 @@ extension SetRateViewController {
 
             } catch {
                 await MainActor.run {
+                    print("❌ Meal 리뷰 업로드 실패: \(error)")
                     self.showToast(message: TextLiteral.Review.uploadReviewFail)
                 }
             }

--- a/EATSSU/App/Sources/Presentation/Splash/NoticeSplashViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Splash/NoticeSplashViewController.swift
@@ -33,7 +33,7 @@ class NoticeSplashViewController: BaseViewController {
 
     private let titleLabel: UILabel = {
         let label = UILabel()
-        label.text = "긴급 서버 점검 안내"
+        label.text = TextLiteral.Splash.serverInspection
         label.font = EATSSUDesignFontFamily.Pretendard.bold.font(size: 16)
         label.textColor = .primary
         label.textAlignment = .center

--- a/EATSSU/App/Sources/Presentation/TabBar/CustomTabBarContainerController.swift
+++ b/EATSSU/App/Sources/Presentation/TabBar/CustomTabBarContainerController.swift
@@ -56,9 +56,9 @@ final class CustomTabBarContainerController: UITabBarController {
     
     private func setupViewControllers() {
         let tabConfigurations: [(title: String, normal: UIImage, selected: UIImage, size: CGSize)] = [
-            ("학식", EATSSUDesignAsset.Images.tabMeal.image, EATSSUDesignAsset.Images.tabMealSelected.image, CGSize(width: 23, height: 23)),
-            ("지도", EATSSUDesignAsset.Images.tabMap.image, EATSSUDesignAsset.Images.tabMapSelected.image, CGSize(width: 23, height: 23)),
-            ("마이", EATSSUDesignAsset.Images.tabMypage.image, EATSSUDesignAsset.Images.tabMypageSelected.image, CGSize(width: 44, height: 23))
+            (TextLiteral.TabBar.meal, EATSSUDesignAsset.Images.tabMeal.image, EATSSUDesignAsset.Images.tabMealSelected.image, CGSize(width: 23, height: 23)),
+            (TextLiteral.TabBar.map, EATSSUDesignAsset.Images.tabMap.image, EATSSUDesignAsset.Images.tabMapSelected.image, CGSize(width: 23, height: 23)),
+            (TextLiteral.TabBar.my, EATSSUDesignAsset.Images.tabMypage.image, EATSSUDesignAsset.Images.tabMypageSelected.image, CGSize(width: 44, height: 23))
         ]
 
         tabViewControllers.enumerated().forEach { index, navController in
@@ -109,8 +109,8 @@ final class CustomTabBarContainerController: UITabBarController {
     public func showDialog(
         title: String,
         message: String,
-        cancelButtonTitle: String = "취소하기",
-        confirmButtonTitle: String = "확인",
+        cancelButtonTitle: String = TextLiteral.Common.cancelDark,
+        confirmButtonTitle: String = TextLiteral.Common.confirm,
         confirmAction: @escaping () -> Void
     ) {
         let dialogView = EATSSUDialogView()
@@ -174,15 +174,15 @@ final class CustomTabBarContainerController: UITabBarController {
     /// 로그인 필요 시 알림창 표시
     private func presentLoginAlert() {
         let alert = UIAlertController(
-            title: "로그인이 필요한 서비스입니다",
-            message: "로그인 하시겠습니까?",
+            title: TextLiteral.Common.needLogin,
+            message: TextLiteral.Common.askLogin,
             preferredStyle: .alert
         )
 
-        let confirmAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
+        let confirmAction = UIAlertAction(title: TextLiteral.Common.confirm, style: .default) { [weak self] _ in
             self?.navigateToLogin()
         }
-        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        let cancelAction = UIAlertAction(title: TextLiteral.Common.cancel, style: .cancel)
 
         alert.addAction(confirmAction)
         alert.addAction(cancelAction)

--- a/EATSSU/App/Sources/Utility/Literal/TextLiteral.swift
+++ b/EATSSU/App/Sources/Utility/Literal/TextLiteral.swift
@@ -7,17 +7,567 @@
 
 import Foundation
 
-/*
- 해야 할 일
- - 하위 enum을 사용해서 세분화
- - 마크업 주석으로 해당 리터럴이 의미하는 실제 문자열 기록
- */
-
-// ... existing code ...
-
 enum TextLiteral {
-    // MARK: - Notification
+    
+    // MARK: - KakaoChannel
+    enum KakaoChannel {
+        /// EATSSU 카카오 채널 ID
+        static let id: String = "_ZlVAn"
+    }
 
+    // MARK: - Common
+    
+    enum Common {
+        /// "확인"
+        static let confirm: String = "확인"
+        
+        /// "취소"
+        static let cancel: String = "취소"
+        
+        /// "취소하기"
+        static let cancelDark: String = "취소하기"
+        
+        /// "삭제하기"
+        static let delete: String = "삭제하기"
+        
+        /// "수정하기"
+        static let fix: String = "수정하기"
+
+        /// "로그인이 필요한 서비스입니다"
+        static let needLogin: String = "로그인이 필요한 서비스입니다"
+        
+        /// "로그인 하시겠습니까?"
+        static let askLogin: String = "로그인 하시겠습니까?"
+        
+        /// "설정으로 이동"
+        static let moveToSetting: String = "설정으로 이동"
+        
+        /// "탈퇴 처리가 완료되었습니다."
+        static let withdrawComplete: String = "탈퇴 처리가 완료되었습니다."
+        
+        /// "잠시 후 다시 시도해주세요."
+        static let tryAgain: String = "잠시 후 다시 시도해주세요."
+        
+        /// "세션이 만료되었습니다. 다시 로그인해주세요."
+        static let sessionExpired: String = "세션이 만료되었습니다. 다시 로그인해주세요."
+
+        /// "에러가 발생했습니다"
+        static let errorOccured: String = "에러가 발생했습니다"
+        
+        /// "다시 시도하세요"
+        static let retry: String = "다시 시도하세요"
+    }
+    
+    // MARK: - TabBar
+    
+    enum TabBar {
+        /// "학식"
+        static let meal: String = "학식"
+        
+        /// "지도"
+        static let map: String = "지도"
+        
+        /// "마이"
+        static let my: String = "마이"
+    }
+
+    // MARK: - Auth
+    
+    enum Auth {
+        /// "닉네임을 입력해주세요"
+        static let inputNickName: String = "닉네임을 입력해주세요"
+
+        /// "Apple로 로그인"
+        static let signInWithApple: String = "Apple로 로그인"
+        
+        /// "카카오 로그인"
+        static let signInWithKakao: String = "카카오 로그인"
+
+        /// "둘러보기"
+        static let lookingWithNoSignIn: String = "둘러보기"
+
+        /// LoginVC - "카카오톡으로 생성된 계정입니다."
+        static let kakaoAccount: String = "카카오톡으로 생성된 계정입니다."
+
+        /// LoginVC - "Apple로 생성된 계정입니다."
+        static let appleAccount: String = "Apple로 생성된 계정입니다."
+
+        /// SetNickNameView - "닉네임 설정"
+        static let setNickname: String = "닉네임 설정"
+
+        /// SetNickNameView - "중복 확인"
+        static let checkDuplicate: String = "중복 확인"
+        
+        /// SetNickNameView - "소속 설정"
+        static let setCollege: String = "소속 설정"
+
+        /// SetNickNameView - "단과대"
+        static let college: String = "단과대"
+
+        /// SetNickNameView - "학과"
+        static let department: String = "학과"
+        
+        /// SetNickNameView - "연결된 계정"
+        static let linkedAccount: String = "연결된 계정"
+
+        /// SetNickNameView - "없음"
+        static let empty: String = "없음"
+        
+        /// SetNickNameView - "저장하기"
+        static let save: String = "저장하기"
+
+        /// SetNickNameView - "카카오"
+        static let kakao: String = "카카오"
+        
+        /// SetNickNameVC - "변경된 정보가 없습니다."
+        static let noChanges: String = "변경된 정보가 없습니다."
+        
+        /// SetNickNameVC - "유효하지 않은 학과 정보입니다."
+        static let invalidDepartment: String = "유효하지 않은 학과 정보입니다."
+
+        /// SetNickNameVC - "정보 업데이트 중 오류가 발생했습니다."
+        static let updateError: String = "정보 업데이트 중 오류가 발생했습니다."
+        
+        /// SetNickNameVC - "내 정보가 수정되었어요."
+        static let updateSuccess: String = "내 정보가 수정되었어요."
+
+        /// NIcknameTextFieldResultType - "필수 입력 사항입니다"
+        static let requiredInput: String = "필수 입력 사항입니다"
+        
+        /// NIcknameTextFieldResultType - "중복 확인을 진행해주세요."
+        static let needCheckDuplicate: String = "중복 확인을 진행해주세요."
+
+        /// NIcknameTextFieldResultType - "이미 사용 중인 닉네임이에요."
+        static let duplicatedNickname: String = "이미 사용 중인 닉네임이에요."
+        
+        /// NIcknameTextFieldResultType - "사용가능한 닉네임이에요"
+        static let availableNickname: String = "사용가능한 닉네임이에요"
+        
+        /// NIcknameTextFieldResultType - "2~16글자를 입력해 주세요."
+        static let nicknameLength: String = "2~16글자를 입력해 주세요."
+
+        /// NIcknameTextFieldResultType - "특수문자로 시작/끝나는 닉네임은 사용할 수 없어요."
+        static let specialCharNickname: String = "특수문자로 시작/끝나는 닉네임은 사용할 수 없어요."
+
+        /// NIcknameTextFieldResultType - "연속된 특수문자(--, __)는 사용할 수 없어요."
+        static let continuousSpecialChar: String = "연속된 특수문자(--, __)는 사용할 수 없어요."
+        
+        /// NIcknameTextFieldResultType - "숫자만으로 된 닉네임은 사용할 수 없어요."
+        static let numberOnlyNickname: String = "숫자만으로 된 닉네임은 사용할 수 없어요."
+
+        /// NIcknameTextFieldResultType - "허용 문자(한글/영문/숫자)만 사용할 수 있어요."
+        static let allowedChar: String = "허용 문자(한글/영문/숫자)만 사용할 수 있어요."
+        
+        /// NIcknameTextFieldResultType - "사용할 수 없는 단어가 포함되어 있어요."
+        static let bannedWord: String = "사용할 수 없는 단어가 포함되어 있어요."
+        
+        /// NIcknameTextFieldResultType - "띄어쓰기로 시작/끝나는 닉네임은 사용할 수 없어요."
+        static let spaceNickname: String = "띄어쓰기로 시작/끝나는 닉네임은 사용할 수 없어요."
+        
+        /// NIcknameTextFieldResultType - "연속된 띄어쓰기는 사용할 수 없어요."
+        static let continuousSpace: String = "연속된 띄어쓰기는 사용할 수 없어요."
+
+        /// NIcknameTextFieldResultType - "이모지, 특수문자는 사용할 수 없어요."
+        static let emojiSpecialChar: String = "이모지, 특수문자는 사용할 수 없어요."
+
+        /// NIcknameTextFieldResultType - "관리자로 혼동될 수 있는 닉네임은 사용할 수 없어요."
+        static let adminNickname: String = "관리자로 혼동될 수 있는 닉네임은 사용할 수 없어요."
+
+        /// NIcknameTextFieldResultType - "서비스명 단독 닉네임은 사용할 수 없어요."
+        static let serviceNameNickname: String = "서비스명 단독 닉네임은 사용할 수 없어요."
+        
+        /// NIcknameTextFieldResultType - "욕설, 비속어 등의 표현이 포함된 닉네임은 사용할 수 없어요."
+        static let slangNickname: String = "욕설, 비속어 등의 표현이 포함된 닉네임은 사용할 수 없어요."
+    }
+
+    // MARK: - Home
+    
+    enum Home {
+        /// Home - "오늘의 메뉴"
+        static let todayMenu: String = "오늘의 메뉴"
+
+        /// Home - "가격"
+        static let price: String = "가격"
+
+        /// Home - "평점"
+        static let rating: String = "평점"
+
+        /// Home - "  -"
+        static let emptyRating: String = "  -"
+
+        /// Home - "제공되는 메뉴가 없습니다"
+        static let noMenuProvidedMessage: String = "제공되는 메뉴가 없습니다"
+        
+        /// CustomTimeTabController - "아침"
+        static let morning: String = "아침"
+        
+        /// CustomTimeTabController - "점심"
+        static let lunch: String = "점심"
+        
+        /// CustomTimeTabController - "저녁"
+        static let dinner: String = "저녁"
+        
+        /// RestaurantInfoView - "학생 식당"
+        static let studentRestaurant: String = "학생 식당"
+
+        /// RestaurantInfoView - "식당 위치"
+        static let restaurantLocation: String = "식당 위치"
+
+        /// RestaurantInfoView - "식당 사진"
+        static let restaurantPicture: String = "식당 사진"
+        
+        /// RestaurantInfoView - "숭실대학교"
+        static let soongsilUniversity: String = "숭실대학교"
+
+        /// RestaurantInfoView - "영업 시간"
+        static let businessHour: String = "영업 시간"
+
+        /// RestaurantInfoView - "비고"
+        static let note: String = "비고"
+        
+        /// RestaurantInfoView - "아시안푸드, 돈까스, 샐러드, 국밥 등\n카페"
+        static let dodamEtc: String = "아시안푸드, 돈까스, 샐러드, 국밥 등\n카페"
+        
+        /// RestaurantMenuGroupCell - "영업 시간이 아니에요."
+        static let notBusinessHour: String = "영업 시간이 아니에요."
+
+        /// RestaurantTableViewHeader - "기숙사 식당"
+        static let dormitoryRestaurant: String = "기숙사 식당"
+    }
+
+    // MARK: - Map
+    
+    enum Map {
+        /// MainMapVC - "제휴 지도"
+        static let map: String = "제휴 지도"
+
+        /// MainMapView - "전체"
+        static let all: String = "전체"
+
+        /// MainMapView - "내 제휴"
+        static let myPartner: String = "내 제휴"
+
+        /// NoDepartmentSheetVC - "학과를 입력하고\n나만의 제휴를 확인해보세요!"
+        static let inputDepartment: String = "학과를 입력하고\n나만의 제휴를 확인해보세요!"
+        
+        /// NoDepartmentSheetVC - "학과 입력하기"
+        static let inputDepartmentButton: String = "학과 입력하기"
+
+        /// PartnershipDetailSheetVC - "음식점"
+        static let restaurant: String = "음식점"
+
+        /// PartnershipDetailSheetVC - "카페"
+        static let cafe: String = "카페"
+
+        /// PartnershipDetailSheetVC - "주점"
+        static let pub: String = "주점"
+
+        /// PartnershipDetailSheetVC - "학과 정보 없음"
+        static let noDepartmentInfo: String = "학과 정보 없음"
+
+        /// MainMapVC+Location - "위치 권한 필요"
+        static let needLocationAuth: String = "위치 권한 필요"
+        
+        /// MainMapVC+Location - "지도에서 내 위치를 바로 확인하고, 현재 위치 주변의 제휴점들을 손쉽게 찾아볼 수 있도록 위치 권한을 허용해 주세요."
+        static let locationAuthDescription: String = "지도에서 내 위치를 바로 확인하고, 현재 위치 주변의 제휴점들을 손쉽게 찾아볼 수 있도록 위치 권한을 허용해 주세요."
+    }
+
+    // MARK: - MyPage
+    
+    enum MyPage {
+        /// "마이페이지"
+        static let myPage: String = "마이페이지"
+
+        /// "내 정보"
+        static let myInfo: String = "내 정보"
+
+        /// "내 리뷰"
+        static let myReview: String = "내 리뷰"
+        
+        /// UserWithdrawVC - "회원탈퇴"
+        static let withdraw: String = "회원탈퇴"
+        
+        /// MyPageVC - "로그아웃"
+        static let logout: String = "로그아웃"
+        
+        /// MyPageVC - "정말 로그아웃 하시겠습니까?"
+        static let askLogout: String = "정말 로그아웃 하시겠습니까?"
+        
+        /// MyPageVC - "EAT-SSU 수신 동의"
+        static func agreeNoti(date: String) -> String {
+            return "EAT-SSU 수신 동의 (\(date))"
+        }
+        
+        /// MyPageVC - "EAT-SSU 수신 거절"
+        static func disagreeNoti(date: String) -> String {
+            return "EAT-SSU 수신 거절 (\(date))"
+        }
+
+        /// MyPageVC - "알림 설정 중 오류가 발생했습니다."
+        static let notiSettingError: String = "알림 설정 중 오류가 발생했습니다."
+        
+        /// CreatorVC - "만든 사람들"
+        static let creators: String = "만든 사람들"
+
+        /// MyReviewVC - "리뷰 수정 혹은 삭제"
+        static let fixOrDeleteReview: String = "리뷰 수정 혹은 삭제"
+        
+        /// MyReviewVC - "작성하신 리뷰를 수정 또는 삭제하시겠습니까?"
+        static let askFixOrDeleteReview: String = "작성하신 리뷰를 수정 또는 삭제하시겠습니까?"
+        
+        /// MyReviewVC - "리뷰 삭제하기"
+        static let deleteMyReview: String = "리뷰 삭제하기"
+        
+        /// MyReviewVC - "해당 리뷰를 삭제할까요?"
+        static let askDeleteMyReview: String = "해당 리뷰를 삭제할까요?"
+        
+        /// MyReviewVC - "리뷰가 성공적으로 삭제되었습니다."
+        static let deleteMyReviewSuccess: String = "리뷰가 성공적으로 삭제되었습니다."
+        
+        /// MyPageView - "다시 시도해주세요"
+        static let retry: String = "다시 시도해주세요"
+        
+        /// MyPageView - "앱 버전"
+        static let appVersion: String = "앱 버전"
+        
+        /// MyPageView - "탈퇴하기"
+        static let withdrawButton: String = "탈퇴하기"
+        
+        /// NotificationSettingTableViewCell - "푸시 알림 설정"
+        static let pushNotificationSetting: String = "푸시 알림 설정"
+        
+        /// Push Notification key for UserDefaults
+        static let pushNotificationUserSettingKey: String = "pushNotificationUserSettingKey"
+
+        /// NotificationSettingTableViewCell - "매일 오전 11시에 알림을 보내드려요"
+        static let pushNotificationDescription: String = "매일 오전 11시에 알림을 보내드려요"
+
+        /// MyPageVC - "문의하기"
+        static let inquiry: String = "문의하기"
+
+        /// MyPageVC - "서비스 이용약관"
+        static let termsOfUse: String = "서비스 이용약관"
+
+        /// MyPageVC - "개인정보 이용약관"
+        static let privacyTermsOfUse: String = "개인정보 이용약관"
+
+        /// ProvisionVC - "이용약관"
+        static let defaultTerms: String = "이용약관"
+
+        /// UserWithdrawView - "정말 탈퇴하시겠습니까?"
+        static let confirmWithdrawal: String = "정말 탈퇴하시겠습니까?"
+
+        /// UserWithdrawView - "작성한 리뷰 게시글은 삭제되지 않으며, (알수없음)으로 표시됩니다.\n자세한 내용은 서비스이용약관 및 개인정보처리방침을 확인해 주세요."
+        static let withdrawalNotice: String = "작성한 리뷰 게시글은 삭제되지 않으며, (알수없음)으로 표시됩니다.\n자세한 내용은 서비스이용약관 및 개인정보처리방침을 확인해 주세요."
+
+        /// UserWithdrawView - "올바른 입력입니다."
+        static let validInputMessage: String = "올바른 입력입니다"
+
+        /// UserWithdrawView - "올바르지 않은 닉네임입니다"
+        static let invalidNicknameMessage: String = "올바르지 않은 닉네임입니다"
+    }
+    
+    // MARK: - Review
+    
+    enum Review {
+        /// ReportVC - "EAT SSU 팀에게 보내기"
+        static let sendToTeam: String = "EAT SSU 팀에게 보내기"
+        
+        /// ReportVC - "신고하기"
+        static let report: String = "신고하기"
+        
+        /// ReportVC - "사유를 선택해주세요!"
+        static let selectReason: String = "사유를 선택해주세요!"
+        
+        /// ReportVC - "신고가 성공적으로 접수되었어요!"
+        static let reportSuccess: String = "신고가 성공적으로 접수되었어요!"
+        
+        /// ReportVC, ReportView - "메뉴와 관련없는 내용"
+        static let unrelatedMenu: String = "메뉴와 관련없는 내용"
+        
+        /// ReportVC, ReportView - "음란성, 욕설 등 부적절한 내용"
+        static let inappropriateContent: String = "음란성, 욕설 등 부적절한 내용"
+        
+        /// ReportVC, ReportView - "부적절한 홍보 또는 광고"
+        static let inappropriateAd: String = "부적절한 홍보 또는 광고"
+        
+        /// ReportVC, ReportView - "리뷰 작성 취지에 맞지 않는 내용 (복사글 등)"
+        static let notReviewFormat: String = "리뷰 작성 취지에 맞지 않는 내용 (복사글 등)"
+        
+        /// ReportVC, ReportView - "저작권 도용 의심 (사진 등)"
+        static let copyright: String = "저작권 도용 의심 (사진 등)"
+        
+        /// ReportVC, ReportView - "기타 (하단 내용 작성)"
+        static let etc: String = "기타 (하단 내용 작성)"
+        
+        /// ReportView - "리뷰 신고 사유를 알려주세요"
+        static let reportReason: String = "리뷰 신고 사유를 알려주세요"
+        
+        /// ReportView - "하나의 리뷰에 대해 24시간 내 한 번만 신고 가능합니다."
+        static let reportGuide: String = "하나의 리뷰에 대해 24시간 내 한 번만 신고 가능합니다."
+        
+        /// ReportView - "리뷰 신고 사유를 작성해 주세요"
+        static let inputReportReason: String = "리뷰 신고 사유를 작성해 주세요"
+        
+        /// ReviewVC - "리뷰 작성하기"
+        static let writeReview: String = "리뷰 작성하기"
+        
+        /// ReviewVC - "리뷰가 성공적으로 등록되었습니다."
+        static let registerReviewSuccess: String = "리뷰가 성공적으로 등록되었습니다."
+        
+        /// ReviewVC - "리뷰"
+        static let review: String = "리뷰"
+
+        /// ReviewVC - "리뷰 삭제"
+        static let deleteReview: String = "리뷰 삭제"
+        
+        /// ReviewVC - "해당 리뷰를 삭제할까요?"
+        static let askDeleteReview: String = "해당 리뷰를 삭제할까요?"
+
+        /// ReviewVC - "리뷰 신고하기"
+        static let reportReview: String = "리뷰 신고하기"
+        
+        /// ReviewVC - "해당 리뷰를 신고하시겠습니까?"
+        static let askReportReview: String = "해당 리뷰를 신고하시겠습니까?"
+
+        /// ReviewVC - "리뷰가 성공적으로 삭제되었습니다."
+        static let deleteReviewSuccess: String = "리뷰가 성공적으로 삭제되었습니다."
+        
+        /// ReviewVC - "리뷰 삭제에 실패했습니다."
+        static let deleteReviewFail: String = "리뷰 삭제에 실패했습니다."
+        
+        /// SetRateVC - "리뷰 수정하기"
+        static let fixReview: String = "리뷰 수정하기"
+        
+        /// SetRateVC - "리뷰 남기기"
+        static let leaveReview: String = "리뷰 남기기"
+
+        /// SetRateVC - "%@ 을/를 추천하시겠어요?"
+        static func recommendMenu(menu: String) -> String {
+            return "\(menu) 을/를 추천하시겠어요?"
+        }
+        
+        /// SetRateVC - "%@ 를/을 추천하시겠어요?"
+        static func recommendMenuWithParticle(menu: String) -> String {
+            return "\(menu) 를/을 추천하시겠어요?"
+        }
+        
+        /// SetRateVC - "메뉴를 추천하시겠어요?"
+        static let recommendMenuTitle: String = "메뉴를 추천하시겠어요?"
+        
+        /// SetRateVC - "리뷰 수정 완료하기"
+        static let fixReviewComplete: String = "리뷰 수정 완료하기"
+
+        /// SetRateVC - "완료하기"
+        static let complete: String = "완료하기"
+        
+        /// SetRateVC - "별점을 입력해주세요!"
+        static let inputRating: String = "별점을 입력해주세요!"
+        
+        /// SetRateVC - "메뉴 목록 조회에 실패했습니다."
+        static let loadMenuListFail: String = "메뉴 목록 조회에 실패했습니다."
+        
+        /// SetRateVC - "수정할 리뷰 정보가 없습니다."
+        static let noReviewInfoForFix: String = "수정할 리뷰 정보가 없습니다."
+
+        /// SetRateVC - "리뷰가 성공적으로 수정되었습니다."
+        static let fixReviewSuccess: String = "리뷰가 성공적으로 수정되었습니다."
+        
+        /// SetRateVC - "리뷰 수정에 실패했습니다."
+        static let fixReviewFail: String = "리뷰 수정에 실패했습니다."
+        
+        /// SetRateVC - "식단 정보가 없습니다."
+        static let noMealInfo: String = "식단 정보가 없습니다."
+        
+        /// SetRateVC - "리뷰 업로드에 실패했습니다."
+        static let uploadReviewFail: String = "리뷰 업로드에 실패했습니다."
+        
+        /// SetRateVC - "메뉴 정보가 없습니다."
+        static let noMenuInfo: String = "메뉴 정보가 없습니다."
+        
+        /// SetRateVC - "메뉴에 대한 상세한 리뷰를 작성해주세요"
+        static let inputDetailReview: String = "메뉴에 대한 상세한 리뷰를 작성해주세요"
+        
+        /// SetRateVC - "나가시겠어요?"
+        static let askLeave: String = "나가시겠어요?"
+
+        /// SetRateVC - "지금 나가면 작성한 내용이 저장되지 않습니다."
+        static let leaveWarning: String = "지금 나가면 작성한 내용이 저장되지 않습니다."
+
+        /// SetRateVC - "나가기"
+        static let leave: String = "나가기"
+        
+        /// SetRateVC - "계속 작성"
+        static let continueWriting: String = "계속 작성"
+        
+        /// ReviewEmptyViewCell - "아직 작성된 리뷰가 없어요!"
+        static let noReview: String = "아직 작성된 리뷰가 없어요!"
+
+        /// ReviewEmptyViewCell - "메뉴에 가장 먼저 리뷰를 남겨주세요!"
+        static let beFirstReviewer: String = "메뉴에 가장 먼저 리뷰를 남겨주세요!"
+        
+        /// ReviewEmptyViewCell - "로그인이 필요합니다"
+        static let needLogin: String = "로그인이 필요합니다"
+        
+        /// ReviewEmptyViewCell - "로그인 후 리뷰를 확인하세요"
+        static let checkReviewAfterLogin: String = "로그인 후 리뷰를 확인하세요"
+        
+        /// ReviewEmptyViewCell - "아직 작성한 리뷰가 없어요"
+        static let noWrittenReview: String = "아직 작성한 리뷰가 없어요"
+        
+        /// ReviewEmptyViewCell - "첫 리뷰를 남겨 주세요!"
+        static let writeFirstReview: String = "첫 리뷰를 남겨 주세요!"
+
+        /// ReviewDividerCell - "리뷰"
+        static func reviewCount(_ count: Int) -> String {
+            return "리뷰 \(count)"
+        }
+        
+        /// ReviewRateViewCell - "오늘의 메뉴"
+        static let todayMenu: String = "오늘의 메뉴"
+
+        /// ReviewRateViewCell - "5점"
+        static let fiveStars: String = "5점"
+
+        /// ReviewRateViewCell - "4점"
+        static let fourStars: String = "4점"
+
+        /// ReviewRateViewCell - "3점"
+        static let threeStars: String = "3점"
+
+        /// ReviewRateViewCell - "2점"
+        static let twoStars: String = "2점"
+
+        /// ReviewRateViewCell - "1점"
+        static let oneStar: String = "1점"
+
+        /// SetRateView - "오늘의 식사는 어떠셨나요?"
+        static let rateTodayMeal: String = "오늘의 식사는 어떠셨나요?"
+
+        /// SetRateView - "추천하고 싶은 메뉴가 있나요?"
+        static let recommendMenu: String = "추천하고 싶은 메뉴가 있나요?"
+        
+        /// SetRateView - "사진 0/1"
+        static let photoCount: String = "사진 0/1"
+        
+        /// SetRateView - "사진 클릭 시, 삭제됩니다"
+        static let deletePhoto: String = "사진 클릭 시, 삭제됩니다"
+
+        /// SetRateView - "사진 \(%d)/1"
+        static func photoCount(count: Int) -> String {
+            return "사진 \(count)/1"
+        }
+    }
+    
+    // MARK: - Splash
+    
+    enum Splash {
+        /// NoticeSplashVC - "긴급 서버 점검 안내"
+        static let serverInspection: String = "긴급 서버 점검 안내"
+    }
+
+    // MARK: - Notification
+    
     enum Notification {
         /// 🤔 오늘 밥 뭐 먹지…
         static let dailyWeekdayNotificationTitle: String = "🤔 오늘 밥 뭐 먹지…"
@@ -25,133 +575,19 @@ enum TextLiteral {
         /// 오늘의 학식을 확인해보세요!
         static let dailyWeekdayNotificationBody: String = "오늘의 학식을 확인해보세요!"
     }
-
-    enum KakaoChannel {
-        /// EATSSU 카카오 채널 ID
-        static let id: String = "_ZlVAn"
-    }
-
-    // MARK: - Sign In
-
-    static let signInWithApple: String = "Apple로 로그인"
-    static let signInWithKakao: String = "카카오 로그인"
-    static let lookingWithNoSignIn: String = "둘러보기"
-    static let setNickName: String = "내 정보"
-    static let nickNameLabel: String = "닉네임"
-    static let inputNickName: String = "닉네임을 입력해주세요"
-    static let inputNickNameLabel: String = "닉네임을 설정해 주세요."
-    static let doubleCheckNickName: String = "중복확인"
-    static let hintInputNickName: String = "2~16글자로 입력해주세요."
-    static let completeLabel: String = "완료하기"
-
-    // MARK: - Home
-
-    enum Home {
-        /// 오늘의 메뉴
-        static let todayMenu: String = "오늘의 메뉴"
-
-        /// 가격
-        static let price: String = "가격"
-
-        /// 평점
-        static let rating: String = "평점"
-
-        /// -
-        static let emptyRating: String = "  -"
-
-        /// 제공되는 메뉴가 없습니다
-        static let noMenuProvidedMessage: String = "제공되는 메뉴가 없습니다"
-    }
-
-    // MARK: - Restaurant
-
-    static let dormitoryRestaurant: String = "기숙사 식당"
-    static let dodamRestaurant: String = "도담 식당"
-    static let studentRestaurant: String = "학생 식당"
-    static let snackCorner: String = "스낵 코너"
-    static let facultyRestaurant: String = "FACULTY (교직원 전용)"
-    static let dormitoryRawValue: String = "DORMITORY"
-    static let dodamRawValue: String = "DODAM"
-    static let studentRestaurantRawValue: String = "HAKSIK"
-    static let snackCornerRawValue: String = "SNACK_CORNER"
-    static let facultyRestaurantRawValue: String = "FACULTY"
-    static let lunchRawValue: String = "LUNCH"
     
-    // MARK: - Time
-
-    static let morning: String = "아침"
-    static let lunch: String = "점심"
-    static let dinner: String = "저녁"
-
-    // MARK: - MyPage
-
-    /// "마이페이지" 텍스트 리터럴
-    enum MyPage {
-        /// "설정에서 알림수신을 동의해주세요!"
-        static let authorizeNotificationSettingMessage: String = "설정에서 알림수신을 동의해주세요!"
-
-        /// "푸시 알림 사용자 설정 접근 키"
-        static let pushNotificationUserSettingKey: String = "pushNotificationUserSettingKey"
-
-        /// "푸시 알림 설정"
-        static let pushNotificationSetting: String = "푸시 알림 설정"
-
-        /// "만든사람들"
-        static let creators: String = "만든사람들"
-
-        /// "마이페이지
-        static let myPage: String = "마이페이지"
-        
-        /// "내 정보"
-        static let MyInfo: String = "내 정보"
-
-        /// "연결된 계정"
-        static let linkedAccount: String = "연결된 계정"
-
-        /// "내가 쓴 리뷰"
-        static let myReview: String = "내 리뷰"
-
-        /// "로그아웃"
-        static let logout: String = "로그아웃"
-
-        /// "탈퇴하기"
-        static let withdraw: String = "회원탈퇴"
-
-        /// "이용약관"
-        static let defaultTerms: String = "이용약관"
-
-        /// "서비스 이용약관"
-        static let termsOfUse: String = "서비스 이용약관"
-
-        /// "개인정보 이용약관"
-        static let privacyTermsOfUse: String = "개인정보 이용약관"
-
-        /// "앱 버전"
-        static let appVersion: String = "앱 버전"
-
-        /// "닉네임 변경"
-        static let changeNickname: String = "닉네임 변경"
-
-        /// "새로운 닉네임"
-        static let newNickname: String = "새로운 닉네임"
-
-        /// "기존 닉네임"
-        static let existingNickname: String = "기존 닉네임"
-
-        /// "문의하기"
-        static let inquiry: String = "문의하기"
-
-        /// "정말 탈퇴하시겠습니까?"
-        static let confirmWithdrawal: String = "정말 탈퇴하시겠습니까?"
-
-        /// "작성한 리뷰 게시글은 삭제되지 않으며, (알수없음)으로 표시됩니다.\n자세한 내용은 서비스이용약관 및 개인정보처리방침을 확인해 주세요."
-        static let withdrawalNotice: String =
-            "작성한 리뷰 게시글은 삭제되지 않으며, (알수없음)으로 표시됩니다.\n자세한 내용은 서비스이용약관 및 개인정보처리방침을 확인해 주세요."
-
-        /// "올바른 입력입니다."
-        static let validInputMessage: String = "올바른 입력입니다"
-
-        /// "올바르지 않은 닉네임입니다"
-        static let invalidNicknameMessage: String = "올바르지 않은 닉네임입니다"
+    // MARK: - Restaurant
+    
+    enum Restaurant {
+        /// "기숙사 식당"
+        static let dormitoryRestaurant: String = "기숙사 식당"
+        /// "도담 식당"
+        static let dodamRestaurant: String = "도담 식당"
+        /// "학생 식당"
+        static let studentRestaurant: String = "학생 식당"
+        /// "스낵 코너"
+        static let snackCorner: String = "스낵 코너"
+        /// "FACULTY (교직원 전용)"
+        static let facultyRestaurant: String = "FACULTY (교직원 전용)"
     }
 }

--- a/EATSSU/App/Sources/Utility/Literal/TextLiteral.swift
+++ b/EATSSU/App/Sources/Utility/Literal/TextLiteral.swift
@@ -118,6 +118,9 @@ enum TextLiteral {
 
         /// SetNickNameView - "카카오"
         static let kakao: String = "카카오"
+
+        /// SetNickNameView - "APPLE"
+        static let apple: String = "APPLE"
         
         /// SetNickNameVC - "변경된 정보가 없습니다."
         static let noChanges: String = "변경된 정보가 없습니다."
@@ -332,6 +335,9 @@ enum TextLiteral {
         
         /// MyPageView - "탈퇴하기"
         static let withdrawButton: String = "탈퇴하기"
+
+        /// MyPageView - "알 수 없음"
+        static let unknownUser: String = "알 수 없음"
         
         /// NotificationSettingTableViewCell - "푸시 알림 설정"
         static let pushNotificationSetting: String = "푸시 알림 설정"
@@ -442,14 +448,26 @@ enum TextLiteral {
         /// SetRateVC - "리뷰 남기기"
         static let leaveReview: String = "리뷰 남기기"
 
-        /// SetRateVC - "%@ 을/를 추천하시겠어요?"
-        static func recommendMenu(menu: String) -> String {
-            return "\(menu) 을/를 추천하시겠어요?"
-        }
-        
-        /// SetRateVC - "%@ 를/을 추천하시겠어요?"
-        static func recommendMenuWithParticle(menu: String) -> String {
-            return "\(menu) 를/을 추천하시겠어요?"
+        /// 메뉴 이름의 받침 유무에 따라 '을/를'을 동적으로 붙여 추천 문장을 생성합니다.
+        static func recommendMenu(name: String) -> String {
+            guard let lastChar = name.last,
+                  let lastScalar = lastChar.unicodeScalars.first else {
+                return "\(name)을(를) 추천하시겠어요?" // 예외 처리
+            }
+            
+            // '가' ~ '힣' 사이의 한글 유니코드 범위
+            let hangulStart: UInt32 = 0xAC00
+            let hangulEnd: UInt32 = 0xD7A3
+            
+            // 받침이 있는지 계산 (종성 코드 확인)
+            if lastScalar.value >= hangulStart && lastScalar.value <= hangulEnd {
+                let hasJongseong = (lastScalar.value - hangulStart) % 28 != 0
+                if hasJongseong {
+                    return "\(name)을 추천하시겠어요?" // 받침 있음
+                }
+            }
+            
+            return "\(name)를 추천하시겠어요?" // 받침 없음
         }
         
         /// SetRateVC - "메뉴를 추천하시겠어요?"
@@ -556,6 +574,11 @@ enum TextLiteral {
         /// SetRateView - "사진 \(%d)/1"
         static func photoCount(count: Int) -> String {
             return "사진 \(count)/1"
+        }
+
+        /// character count
+        static func characterCount(current: Int, max: Int) -> String {
+            return "\(current) / \(max)"
         }
     }
     


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #377 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

제시해주신 PR 내용을 바탕으로 리팩토링 사항을 한국어로 요약해 드립니다.

---

### 📝 리팩토링 주요 요약


#### UI 문자열 중앙화 및 교체

* **인증 레이어 리팩토링:** 
  * `SetNickNameView`, `SetNickNameViewController`, `LoginViewController` 내의 모든 하드코딩된 문자열을 제거했습니다.
  * 레이블, 버튼 타이틀, 유효성 검사 메시지, 토스트 메시지 등을 `TextLiteral.Auth` 및 `TextLiteral.Common` 상수로 대체하였습니다.


* **홈 레이어 및 분석 도구 업데이트**
  * `HomeAnalyticsManager`와 모든 홈 뷰 컴포넌트의 문자열을 업데이트했습니다.
  * 식당 이름, 식사 시간, 위치 정보, 메모 및 상태 메시지 등에 `TextLiteral.Home` 및 `TextLiteral.Restaurant`을 적용했습니다.

---


### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 한국어와 함께 다른 언어(영어)를 지원하기 위한 기능을 도입하기 전에 텍스트를 전부 정리하였습니다.