### PR TITLE
[#380] 로그인 화면 진입 시, realm 데이터 제거

### DIFF
--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
@@ -34,6 +34,10 @@ final class LoginViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        // 로그인 화면 진입 시 로컬 데이터 초기화 (데이터 불일치 방지)
+        RealmService.shared.resetDB()
+        
         configureFirebaseRemoteConfig()
     }
     


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #380 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

<img width="327" height="118" alt="image" src="https://github.com/user-attachments/assets/dcc1c966-fd12-41bd-8630-f69e12c3287f" />

- `../department/partnerships`이 현재 유저의 학과 조회 API를 쏘고 요청하던 API인데, 로컬에 저장되어있는 경우 바로 요청하게 됩니다. 
- 그래서 로그인 화면에 한번이라도 접속하게 되면 realm에 저장되어있는 정보를 날리는 방법으로 일단 예방했습니다.
- 일단 1차로 의심되는 상황을 제거했는데, 또 에러가 발생하게 된다면 다른 방법으로 접근해봐야할 것 같습니다.

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- X
