### PR TITLE
[#386] 학과 정보 없을 때 MISSING_USER_DEPARTMENT 에러 방지

### DIFF
--- a/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController+Network.swift
+++ b/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController+Network.swift
@@ -34,30 +34,49 @@ extension MainMapViewController {
             useAuth: true
         ) { [weak self] result in
             guard let self = self else { return }
-            
+
             switch result {
             case .success(let department):
                 let departmentName = department.departmentName
                 self.currentDepartmentName = departmentName
                 self.currentDepartmentId = department.departmentId
                 self.currentCollegeId = department.collegeId
-                
+
                 let buttonTitle = departmentName.isEmpty ? TextLiteral.Map.myPartner : departmentName
                 self.root.myOnlyButton.setTitle(buttonTitle, for: .normal)
-                
+
             case .failure(let error):
                 print("학과 조회 실패: \(error.localizedDescription)")
                 self.currentDepartmentName = nil
                 self.currentDepartmentId = nil
                 self.currentCollegeId = nil
                 self.root.myOnlyButton.setTitle(TextLiteral.Map.myPartner, for: .normal)
+
+                // Realm 데이터도 함께 동기화하여 서버-클라이언트 불일치 방지
+                if let userInfo = UserInfoManager.shared.getCurrentUserInfo() {
+                    UserInfoManager.shared.updateDepartment(
+                        for: userInfo,
+                        collegeId: nil,
+                        collegeName: nil,
+                        departmentId: nil,
+                        departmentName: nil
+                    )
+                }
             }
-            
+
             completion?()
         }
     }
     
     func fetchMyPartnerships() {
+        // 학과 정보가 없으면 API 호출하지 않음 (서버 에러 방지)
+        guard let departmentName = currentDepartmentName,
+              !departmentName.isEmpty else {
+            print("학과 정보가 없어 학과별 제휴 조회를 건너뜁니다")
+            displayMarkers([])
+            return
+        }
+
         NetworkService.shared.request(
             MyRouter.getMyPartnerships,
             responseType: [PartnershipDTO].self,
@@ -66,7 +85,7 @@ extension MainMapViewController {
             switch result {
             case .success(let partnerships):
                 self?.displayMarkers(partnerships)
-                
+
             case .failure(let error):
                 print("내 제휴 조회 실패: \(error.localizedDescription)")
             }

--- a/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController+Network.swift
+++ b/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController+Network.swift
@@ -45,6 +45,17 @@ extension MainMapViewController {
                 let buttonTitle = departmentName.isEmpty ? TextLiteral.Map.myPartner : departmentName
                 self.root.myOnlyButton.setTitle(buttonTitle, for: .normal)
 
+                // Realm 데이터도 함께 동기화하여 서버-클라이언트 불일치 방지
+                if let userInfo = UserInfoManager.shared.getCurrentUserInfo() {
+                    UserInfoManager.shared.updateDepartment(
+                        for: userInfo,
+                        collegeId: department.collegeId,
+                        collegeName: department.collegeName,
+                        departmentId: department.departmentId,
+                        departmentName: department.departmentName
+                    )
+                }
+
             case .failure(let error):
                 print("학과 조회 실패: \(error.localizedDescription)")
                 self.currentDepartmentName = nil
@@ -88,6 +99,7 @@ extension MainMapViewController {
 
             case .failure(let error):
                 print("내 제휴 조회 실패: \(error.localizedDescription)")
+                self?.displayMarkers([])
             }
         }
     }


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #386 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요
1. API 호출 전 검증 추가: `fetchMyPartnerships()`에서 학과 정보 없으면 API 호출 차단
2. Realm 동기화: 서버 조회 실패 시 Realm 데이터도 함께 초기화하여 데이터 일관성 유지

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
