### PR TITLE
[#394] Posthog 도입 완료

### DIFF
--- a/EATSSU/App/Sources/Data/Firebase/AnalyticsService.swift
+++ b/EATSSU/App/Sources/Data/Firebase/AnalyticsService.swift
@@ -25,7 +25,7 @@ enum AnalyticsService {
         ])
         #if !DEBUG
         PostHogSDK.shared.screen(name, properties: [
-            "screen_class": screenClass
+            AnalyticsParameterScreenClass: screenClass
         ])
         #endif
     }

--- a/EATSSU/App/Sources/Data/Firebase/AnalyticsService.swift
+++ b/EATSSU/App/Sources/Data/Firebase/AnalyticsService.swift
@@ -1,0 +1,32 @@
+//
+//  AnalyticsService.swift
+//  EATSSU
+//
+//  Created on 2026/03/04.
+//
+
+import FirebaseAnalytics
+import PostHog
+
+enum AnalyticsService {
+    /// 커스텀 이벤트 로깅 (Firebase + PostHog)
+    static func logEvent(_ name: String, parameters: [String: Any]? = nil) {
+        Analytics.logEvent(name, parameters: parameters)
+        #if !DEBUG
+        PostHogSDK.shared.capture(name, properties: parameters)
+        #endif
+    }
+
+    /// 화면 조회 로깅 (Firebase + PostHog)
+    static func logScreen(_ name: String, screenClass: String) {
+        Analytics.logEvent(AnalyticsEventScreenView, parameters: [
+            AnalyticsParameterScreenName: name,
+            AnalyticsParameterScreenClass: screenClass
+        ])
+        #if !DEBUG
+        PostHogSDK.shared.screen(name, properties: [
+            "screen_class": screenClass
+        ])
+        #endif
+    }
+}

--- a/EATSSU/App/Sources/Data/Firebase/HomeAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/HomeAnalyticsManager.swift
@@ -6,34 +6,32 @@
 //
 
 import Foundation
-import FirebaseAnalytics
-import PostHog
 
 /// 홈 화면에서 발생하는 주요 이벤트를 Firebase Analytics에 로깅하는 담당자
 final class HomeAnalyticsManager {
-    
+
     // MARK: - Singleton
-    
+
     static let shared = HomeAnalyticsManager()
     private init() {}
-    
+
     // MARK: - Event & Parameter Keys
-    
+
     private enum Event {
         static let clickRestaurantInfo = "click_restaurant_info"
         static let selectMealTime = "select_mealtime"
         static let selectDay = "select_day"
         static let clickMenu = "click_menu"
     }
-    
+
     private enum Parameter {
         static let restaurants = "restaurants"
         static let mealTime = "mealtime"
         static let day = "day"
     }
-    
+
     // MARK: - Mappers
-        
+
     // 식당 이름(한글) -> 영문 소문자 파라미터로 변환
     private let restaurantNameMap: [String: String] = [
         TextLiteral.Restaurant.studentRestaurant: "haksik",
@@ -41,14 +39,14 @@ final class HomeAnalyticsManager {
         TextLiteral.Restaurant.dormitoryRestaurant: "dormitory",
         TextLiteral.Restaurant.facultyRestaurant: "faculty"
     ]
-    
+
     // 식사 유형(한글) -> 영문 소문자 파라미터로 변환
     private let mealTimeMap: [String: String] = [
         TextLiteral.Home.morning: "breakfast",
         TextLiteral.Home.lunch: "lunch",
         TextLiteral.Home.dinner: "dinner"
     ]
-    
+
     // Date 객체 -> 요일(영문 소문자) 문자열로 변환
     private let dayFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -56,7 +54,7 @@ final class HomeAnalyticsManager {
         formatter.locale = Locale(identifier: "en_US")
         return formatter
     }()
-    
+
     // MARK: - Logging Methods
 
     /**
@@ -68,15 +66,12 @@ final class HomeAnalyticsManager {
             print("Analytics Error: Invalid restaurant name for click_restaurant_info - \(restaurantName)")
             return
         }
-        
-        Analytics.logEvent(Event.clickRestaurantInfo, parameters: [
-            Parameter.restaurants: parameterValue
-        ])
-        PostHogSDK.shared.capture(Event.clickRestaurantInfo, properties: [
+
+        AnalyticsService.logEvent(Event.clickRestaurantInfo, parameters: [
             Parameter.restaurants: parameterValue
         ])
     }
-    
+
     /**
      #2 식사 유형(아침, 점심, 저녁) 탭을 변경했을 때 호출
      - Parameter mealTime: 사용자가 선택한 식사 유형 (예: "아침")
@@ -86,26 +81,20 @@ final class HomeAnalyticsManager {
             print("Analytics Error: Invalid meal time for select_mealtime - \(mealTime)")
             return
         }
-        
-        Analytics.logEvent(Event.selectMealTime, parameters: [
-            Parameter.mealTime: parameterValue
-        ])
-        PostHogSDK.shared.capture(Event.selectMealTime, properties: [
+
+        AnalyticsService.logEvent(Event.selectMealTime, parameters: [
             Parameter.mealTime: parameterValue
         ])
     }
-    
+
     /**
      #3 요일(날짜)을 변경했을 때 호출
      - Parameter date: 사용자가 선택한 날짜 (Date 객체)
      */
     func logSelectDay(date: Date) {
         let parameterValue = dayFormatter.string(from: date).lowercased()
-        
-        Analytics.logEvent(Event.selectDay, parameters: [
-            Parameter.day: parameterValue
-        ])
-        PostHogSDK.shared.capture(Event.selectDay, properties: [
+
+        AnalyticsService.logEvent(Event.selectDay, parameters: [
             Parameter.day: parameterValue
         ])
     }
@@ -120,10 +109,7 @@ final class HomeAnalyticsManager {
             return
         }
 
-        Analytics.logEvent(Event.clickMenu, parameters: [
-            Parameter.restaurants: parameterValue
-        ])
-        PostHogSDK.shared.capture(Event.clickMenu, properties: [
+        AnalyticsService.logEvent(Event.clickMenu, parameters: [
             Parameter.restaurants: parameterValue
         ])
     }

--- a/EATSSU/App/Sources/Data/Firebase/HomeAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/HomeAnalyticsManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import FirebaseAnalytics
+import PostHog
 
 /// 홈 화면에서 발생하는 주요 이벤트를 Firebase Analytics에 로깅하는 담당자
 final class HomeAnalyticsManager {
@@ -71,6 +72,9 @@ final class HomeAnalyticsManager {
         Analytics.logEvent(Event.clickRestaurantInfo, parameters: [
             Parameter.restaurants: parameterValue
         ])
+        PostHogSDK.shared.capture(Event.clickRestaurantInfo, properties: [
+            Parameter.restaurants: parameterValue
+        ])
     }
     
     /**
@@ -86,6 +90,9 @@ final class HomeAnalyticsManager {
         Analytics.logEvent(Event.selectMealTime, parameters: [
             Parameter.mealTime: parameterValue
         ])
+        PostHogSDK.shared.capture(Event.selectMealTime, properties: [
+            Parameter.mealTime: parameterValue
+        ])
     }
     
     /**
@@ -96,6 +103,9 @@ final class HomeAnalyticsManager {
         let parameterValue = dayFormatter.string(from: date).lowercased()
         
         Analytics.logEvent(Event.selectDay, parameters: [
+            Parameter.day: parameterValue
+        ])
+        PostHogSDK.shared.capture(Event.selectDay, properties: [
             Parameter.day: parameterValue
         ])
     }
@@ -111,6 +121,9 @@ final class HomeAnalyticsManager {
         }
 
         Analytics.logEvent(Event.clickMenu, parameters: [
+            Parameter.restaurants: parameterValue
+        ])
+        PostHogSDK.shared.capture(Event.clickMenu, properties: [
             Parameter.restaurants: parameterValue
         ])
     }

--- a/EATSSU/App/Sources/Data/Firebase/LaunchSourceManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/LaunchSourceManager.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import FirebaseAnalytics
+import PostHog
 
 enum LaunchSource: String {
     case icon
@@ -76,6 +77,7 @@ final class LaunchSourceManager {
         // 아직 로깅하지 않았으면 로깅 수행
         if !hasLogged {
             Analytics.logEvent("app_launch", parameters: ["launch_path": source.rawValue])
+            PostHogSDK.shared.capture("app_launch", properties: ["launch_path": source.rawValue])
             hasLogged = true
             
             print("App launch logged: \(source.rawValue) (New session: \(isNewSession))")

--- a/EATSSU/App/Sources/Data/Firebase/LaunchSourceManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/LaunchSourceManager.swift
@@ -7,9 +7,6 @@
 
 import UIKit
 
-import FirebaseAnalytics
-import PostHog
-
 enum LaunchSource: String {
     case icon
     case localNotification = "local_notification"
@@ -19,19 +16,19 @@ enum LaunchSource: String {
 
 final class LaunchSourceManager {
     static let shared = LaunchSourceManager()
-    
+
     private(set) var source: LaunchSource = .icon
     private var hasLogged = false
     private var backgroundEntryTime: Date?
     private let newSessionThreshold: TimeInterval = 300
-    
+
     private init() {}
-    
+
     /// 앱 실행 소스를 설정합니다
     /// - Parameter source: 설정할 실행 소스
     func setSource(_ source: LaunchSource) {
         print("소스 설정 시도: \(source.rawValue) (현재 소스: \(self.source.rawValue), 로깅 상태: \(hasLogged))")
-        
+
         // 알림, 위젯을 통해 실행된 경우, 항상 우선적으로 해당 소스로 설정
         // 명시적으로 설정된 실행 경로가 없을 경우 기본값은 .icon
         switch source {
@@ -47,42 +44,41 @@ final class LaunchSourceManager {
             return
         }
     }
-    
+
     /// 앱이 백그라운드로 갈 때 호출
     func appDidEnterBackground() {
         backgroundEntryTime = Date()
     }
-    
+
     /// 새 세션인지 체크 - 앱이 백그라운드에서 일정 시간 이상 있었는지 확인
     /// - Returns: 새 세션 여부
     func checkNewSession() -> Bool {
         // 백그라운드 시간이 없으면 콜드 스타트(앱이 완전히 종료된 후 실행)로 간주
         guard let backgroundTime = backgroundEntryTime else { return true }
-        
+
         let timeDifference = Date().timeIntervalSince(backgroundTime)
         return timeDifference >= newSessionThreshold
     }
-    
+
     /// 필요시 Firebase Analytics에 앱 실행 이벤트 로깅
     func logIfNeeded() {
         // 콜드 스타트이거나 백그라운드에서 오래 있었던 경우(새 세션)
         let isNewSession = checkNewSession()
-        
+
         if isNewSession {
             // 이전에 로깅했던 상태 초기화 (새 세션이므로)
             hasLogged = false
             // 소스는 초기화하지 않음 - 이미 setSource에서 설정된 값 유지
         }
-        
+
         // 아직 로깅하지 않았으면 로깅 수행
         if !hasLogged {
-            Analytics.logEvent("app_launch", parameters: ["launch_path": source.rawValue])
-            PostHogSDK.shared.capture("app_launch", properties: ["launch_path": source.rawValue])
+            AnalyticsService.logEvent("app_launch", parameters: ["launch_path": source.rawValue])
             hasLogged = true
-            
+
             print("App launch logged: \(source.rawValue) (New session: \(isNewSession))")
         }
-        
+
         backgroundEntryTime = nil
     }
 }

--- a/EATSSU/App/Sources/Data/Firebase/MapAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/MapAnalyticsManager.swift
@@ -5,53 +5,47 @@
 //  Created by 황상환 on 9/13/25.
 //
 
-import FirebaseAnalytics
-import PostHog
-
 /// 지도 화면에서 발생하는 주요 이벤트를 Firebase Analytics에 로깅하는 담당자
 final class MapAnalyticsManager {
-    
+
     // MARK: - Singleton
-    
+
     static let shared = MapAnalyticsManager()
     private init() {}
-    
+
     // MARK: - Event & Parameter Keys
-    
+
     private enum Event {
         static let clickMap = "click_map"
         static let clickMapMine = "click_map_mine"
         static let clickPartnerRestaurant = "click_partner_restaurant"
     }
-    
+
     private enum Parameter {
         static let college = "college"
         static let major = "major"
         static let partnerRestaurantId = "partner_restaurant_id"
     }
-    
+
     // MARK: - Logging Methods
 
     /**
      #1 하단 탭바에서 '지도'를 클릭했을 때 호출
      */
     func logClickMap() {
-        Analytics.logEvent(Event.clickMap, parameters: nil)
-        PostHogSDK.shared.capture(Event.clickMap)
+        AnalyticsService.logEvent(Event.clickMap)
     }
-    
+
     /**
      #2 지도 화면에서 '내 제휴' (또는 학과명) 버튼을 클릭했을 때 호출
      - Parameter collegeId: 사용자의 단과대 ID
      - Parameter majorId: 사용자의 학과 ID
      */
     func logClickMapMine(collegeId: Int, majorId: Int) {
-        let parameters: [String: Any] = [
+        AnalyticsService.logEvent(Event.clickMapMine, parameters: [
             Parameter.college: collegeId,
             Parameter.major: majorId
-        ]
-        Analytics.logEvent(Event.clickMapMine, parameters: parameters)
-        PostHogSDK.shared.capture(Event.clickMapMine, properties: parameters)
+        ])
     }
 
     /**
@@ -64,16 +58,15 @@ final class MapAnalyticsManager {
         var parameters: [String: Any] = [
             Parameter.partnerRestaurantId: partnerId
         ]
-        
+
         if let collegeId = collegeId {
             parameters[Parameter.college] = collegeId
         }
-        
+
         if let majorId = majorId {
             parameters[Parameter.major] = majorId
         }
-        
-        Analytics.logEvent(Event.clickPartnerRestaurant, parameters: parameters)
-        PostHogSDK.shared.capture(Event.clickPartnerRestaurant, properties: parameters)
+
+        AnalyticsService.logEvent(Event.clickPartnerRestaurant, parameters: parameters)
     }
 }

--- a/EATSSU/App/Sources/Data/Firebase/MapAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/MapAnalyticsManager.swift
@@ -6,6 +6,7 @@
 //
 
 import FirebaseAnalytics
+import PostHog
 
 /// 지도 화면에서 발생하는 주요 이벤트를 Firebase Analytics에 로깅하는 담당자
 final class MapAnalyticsManager {
@@ -36,6 +37,7 @@ final class MapAnalyticsManager {
      */
     func logClickMap() {
         Analytics.logEvent(Event.clickMap, parameters: nil)
+        PostHogSDK.shared.capture(Event.clickMap)
     }
     
     /**
@@ -49,6 +51,7 @@ final class MapAnalyticsManager {
             Parameter.major: majorId
         ]
         Analytics.logEvent(Event.clickMapMine, parameters: parameters)
+        PostHogSDK.shared.capture(Event.clickMapMine, properties: parameters)
     }
 
     /**
@@ -71,5 +74,6 @@ final class MapAnalyticsManager {
         }
         
         Analytics.logEvent(Event.clickPartnerRestaurant, parameters: parameters)
+        PostHogSDK.shared.capture(Event.clickPartnerRestaurant, properties: parameters)
     }
 }

--- a/EATSSU/App/Sources/Data/Firebase/ReviewAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/ReviewAnalyticsManager.swift
@@ -5,40 +5,36 @@
 //  Created by 황상환 on 9/6/25.
 //
 
-import FirebaseAnalytics
-import PostHog
-
 /// 리뷰 화면에서 발생하는 주요 이벤트를 Firebase Analytics에 로깅하는 담당자
 final class ReviewAnalyticsManager {
-    
+
     // MARK: - Singleton
-    
+
     static let shared = ReviewAnalyticsManager()
     private init() {}
-    
+
     // MARK: - Event & Parameter Keys
-    
+
     private enum Event {
         static let writeReview = "write_review_v1"
         static let completeReview = "complete_review_v1"
     }
-    
+
     private enum Parameter {
         static let photoAttached = "photo_attached"
         static let rating = "rating"
         static let selection = "selection"
     }
-    
+
     // MARK: - Logging Methods
 
     /**
      #1 '리뷰 작성하기' 버튼을 클릭했을 때 호출
      */
     func logWriteReviewV1() {
-        Analytics.logEvent(Event.writeReview, parameters: nil)
-        PostHogSDK.shared.capture(Event.writeReview)
+        AnalyticsService.logEvent(Event.writeReview)
     }
-    
+
     /**
      #2 리뷰 작성을 마치고 '완료하기' 버튼을 클릭했을 때 호출
      - Parameter photoAttached: 사진 첨부 여부 (0: 없음, 1: 있음)
@@ -46,13 +42,10 @@ final class ReviewAnalyticsManager {
      - Parameter selection: 사용자가 한 번에 리뷰를 작성하는 메뉴의 총 개수
      */
     func logCompleteReviewV1(photoAttached: Int, rating: Int, selection: Int) {
-        let parameters: [String: Any] = [
+        AnalyticsService.logEvent(Event.completeReview, parameters: [
             Parameter.photoAttached: photoAttached,
             Parameter.rating: rating,
             Parameter.selection: selection
-        ]
-        
-        Analytics.logEvent(Event.completeReview, parameters: parameters)
-        PostHogSDK.shared.capture(Event.completeReview, properties: parameters)
+        ])
     }
 }

--- a/EATSSU/App/Sources/Data/Firebase/ReviewAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/ReviewAnalyticsManager.swift
@@ -6,6 +6,7 @@
 //
 
 import FirebaseAnalytics
+import PostHog
 
 /// 리뷰 화면에서 발생하는 주요 이벤트를 Firebase Analytics에 로깅하는 담당자
 final class ReviewAnalyticsManager {
@@ -35,6 +36,7 @@ final class ReviewAnalyticsManager {
      */
     func logWriteReviewV1() {
         Analytics.logEvent(Event.writeReview, parameters: nil)
+        PostHogSDK.shared.capture(Event.writeReview)
     }
     
     /**
@@ -51,5 +53,6 @@ final class ReviewAnalyticsManager {
         ]
         
         Analytics.logEvent(Event.completeReview, parameters: parameters)
+        PostHogSDK.shared.capture(Event.completeReview, properties: parameters)
     }
 }

--- a/EATSSU/App/Sources/Data/Firebase/WidgetAnalyticsManager+SendEvents.swift
+++ b/EATSSU/App/Sources/Data/Firebase/WidgetAnalyticsManager+SendEvents.swift
@@ -1,0 +1,26 @@
+//
+//  WidgetAnalyticsManager+SendEvents.swift
+//  EATSSU
+//
+//  메인 앱 타겟에서만 포함되는 파일입니다.
+//  AnalyticsService를 통해 Firebase + PostHog에 위젯 이벤트를 전송합니다.
+//
+
+extension WidgetAnalyticsManager {
+    /// (메인 앱에서 호출) 기록된 위젯 이벤트가 있다면 Analytics로 전송하고 기록을 삭제합니다.
+    func sendPendingEvents() {
+        // 1. 위젯 추가 이벤트 전송
+        if userDefaults?.bool(forKey: UserDefaultsKey.widgetAdded) == true {
+            AnalyticsService.logEvent(Event.addWidget)
+            userDefaults?.removeObject(forKey: UserDefaultsKey.widgetAdded)
+            print("Analytics: Logged add_widget_ios")
+        }
+
+        // 2. 위젯 변경 이벤트 전송
+        if let changeInfo = userDefaults?.dictionary(forKey: UserDefaultsKey.widgetChanged) as? [String: String] {
+            AnalyticsService.logEvent(Event.changeWidget, parameters: changeInfo)
+            userDefaults?.removeObject(forKey: UserDefaultsKey.widgetChanged)
+            print("Analytics: Logged change_widget_ios with params \(changeInfo)")
+        }
+    }
+}

--- a/EATSSU/App/Sources/Data/Firebase/WidgetAnalyticsManager+SendEvents.swift
+++ b/EATSSU/App/Sources/Data/Firebase/WidgetAnalyticsManager+SendEvents.swift
@@ -13,14 +13,18 @@ extension WidgetAnalyticsManager {
         if userDefaults?.bool(forKey: UserDefaultsKey.widgetAdded) == true {
             AnalyticsService.logEvent(Event.addWidget)
             userDefaults?.removeObject(forKey: UserDefaultsKey.widgetAdded)
+            #if DEBUG
             print("Analytics: Logged add_widget_ios")
+            #endif
         }
 
         // 2. 위젯 변경 이벤트 전송
         if let changeInfo = userDefaults?.dictionary(forKey: UserDefaultsKey.widgetChanged) as? [String: String] {
             AnalyticsService.logEvent(Event.changeWidget, parameters: changeInfo)
             userDefaults?.removeObject(forKey: UserDefaultsKey.widgetChanged)
+            #if DEBUG
             print("Analytics: Logged change_widget_ios with params \(changeInfo)")
+            #endif
         }
     }
 }

--- a/EATSSU/App/Sources/Data/Firebase/WidgetAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/WidgetAnalyticsManager.swift
@@ -15,7 +15,18 @@ final class WidgetAnalyticsManager {
     // MARK: - App Group UserDefaults
 
     /// 위젯과 메인 앱이 데이터를 공유하기 위한 공간
-    let userDefaults = UserDefaults(suiteName: Bundle.main.infoDictionary?["AppGroupID"] as? String)
+    let userDefaults: UserDefaults? = {
+        guard let groupID = Bundle.main.infoDictionary?["AppGroupID"] as? String,
+              !groupID.isEmpty else {
+            assertionFailure("AppGroupID가 Info.plist에 설정되어 있지 않습니다.")
+            return nil
+        }
+        guard let defaults = UserDefaults(suiteName: groupID) else {
+            assertionFailure("UserDefaults 초기화 실패: \(groupID)")
+            return nil
+        }
+        return defaults
+    }()
 
     // MARK: - Event & Parameter Keys
 

--- a/EATSSU/App/Sources/Data/Firebase/WidgetAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/WidgetAnalyticsManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import FirebaseAnalytics
+import PostHog
 
 /// 위젯에서 발생하는 이벤트를 Firebase Analytics에 로깅하는 담당자
 final class WidgetAnalyticsManager {
@@ -77,6 +78,7 @@ final class WidgetAnalyticsManager {
         // 1. 위젯 추가 이벤트 전송
         if userDefaults?.bool(forKey: UserDefaultsKey.widgetAdded) == true {
             Analytics.logEvent(Event.addWidget, parameters: nil)
+            PostHogSDK.shared.capture(Event.addWidget)
             userDefaults?.removeObject(forKey: UserDefaultsKey.widgetAdded) // 중복 전송 방지를 위해 기록 삭제
             print("Analytics: Logged add_widget_ios")
         }
@@ -84,6 +86,7 @@ final class WidgetAnalyticsManager {
         // 2. 위젯 변경 이벤트 전송
         if let changeInfo = userDefaults?.dictionary(forKey: UserDefaultsKey.widgetChanged) as? [String: String] {
             Analytics.logEvent(Event.changeWidget, parameters: changeInfo)
+            PostHogSDK.shared.capture(Event.changeWidget, properties: changeInfo)
             userDefaults?.removeObject(forKey: UserDefaultsKey.widgetChanged) // 중복 전송 방지를 위해 기록 삭제
             print("Analytics: Logged change_widget_ios with params \(changeInfo)")
         }

--- a/EATSSU/App/Sources/Data/Firebase/WidgetAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/WidgetAnalyticsManager.swift
@@ -7,35 +7,34 @@
 
 import Foundation
 import FirebaseAnalytics
-import PostHog
 
 /// 위젯에서 발생하는 이벤트를 Firebase Analytics에 로깅하는 담당자
 final class WidgetAnalyticsManager {
-    
+
     static let shared = WidgetAnalyticsManager()
-    
+
     // MARK: - App Group UserDefaults
-    
+
     /// 위젯과 메인 앱이 데이터를 공유하기 위한 공간
     private let userDefaults = UserDefaults(suiteName: Bundle.main.infoDictionary?["AppGroupID"] as? String)
-    
+
     // MARK: - Event & Parameter Keys
-    
+
     private enum Event {
         static let addWidget = "add_widget_ios"
         static let changeWidget = "change_widget_ios"
     }
-    
+
     private enum Parameter {
         static let restaurantBefore = "restaurant_before"
         static let restaurantAfter = "restaurant_after"
     }
-    
+
     private enum UserDefaultsKey {
         static let widgetAdded = "pendingWidgetAddedEvent"
         static let widgetChanged = "pendingWidgetChangedEvent"
     }
-    
+
     /// 한글 식당명을 파라미터 형식(영어 소문자)으로 변환하기 위한 맵
     private let restaurantNameMap: [String: String] = [
         "학생식당": "haksik",
@@ -43,7 +42,7 @@ final class WidgetAnalyticsManager {
         "기숙사 식당": "dormitory",
         "FACULTY (교직원 전용)": "faculty",
     ]
-    
+
     private init() {}
 
     // MARK: - Methods to be Called from Widget Extension
@@ -52,7 +51,7 @@ final class WidgetAnalyticsManager {
     func recordWidgetAdded() {
         userDefaults?.set(true, forKey: UserDefaultsKey.widgetAdded)
     }
-    
+
     /// (위젯에서 호출) 사용자가 위젯의 식당을 변경했을 때, 이전/이후 정보를 기록합니다.
     /// - Parameters:
     ///   - before: 변경 전 식당 이름 (예: "학생식당")
@@ -62,32 +61,31 @@ final class WidgetAnalyticsManager {
               let afterParam = restaurantNameMap[after] else {
             return
         }
-        
+
         let changeInfo = [
             Parameter.restaurantBefore: beforeParam,
             Parameter.restaurantAfter: afterParam
         ]
-        
+
         userDefaults?.set(changeInfo, forKey: UserDefaultsKey.widgetChanged)
     }
-    
+
     // MARK: - Method to be Called from Main App
 
     /// (메인 앱에서 호출) 기록된 위젯 이벤트가 있다면 Firebase로 전송하고 기록을 삭제합니다.
+    /// 이 파일은 위젯 타겟에도 포함되므로, PostHog 의존성 없이 Firebase만 직접 호출합니다.
     func sendPendingEvents() {
         // 1. 위젯 추가 이벤트 전송
         if userDefaults?.bool(forKey: UserDefaultsKey.widgetAdded) == true {
             Analytics.logEvent(Event.addWidget, parameters: nil)
-            PostHogSDK.shared.capture(Event.addWidget)
-            userDefaults?.removeObject(forKey: UserDefaultsKey.widgetAdded) // 중복 전송 방지를 위해 기록 삭제
+            userDefaults?.removeObject(forKey: UserDefaultsKey.widgetAdded)
             print("Analytics: Logged add_widget_ios")
         }
-        
+
         // 2. 위젯 변경 이벤트 전송
         if let changeInfo = userDefaults?.dictionary(forKey: UserDefaultsKey.widgetChanged) as? [String: String] {
             Analytics.logEvent(Event.changeWidget, parameters: changeInfo)
-            PostHogSDK.shared.capture(Event.changeWidget, properties: changeInfo)
-            userDefaults?.removeObject(forKey: UserDefaultsKey.widgetChanged) // 중복 전송 방지를 위해 기록 삭제
+            userDefaults?.removeObject(forKey: UserDefaultsKey.widgetChanged)
             print("Analytics: Logged change_widget_ios with params \(changeInfo)")
         }
     }

--- a/EATSSU/App/Sources/Data/Firebase/WidgetAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/WidgetAnalyticsManager.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import FirebaseAnalytics
 
 /// 위젯에서 발생하는 이벤트를 Firebase Analytics에 로깅하는 담당자
 final class WidgetAnalyticsManager {
@@ -16,11 +15,11 @@ final class WidgetAnalyticsManager {
     // MARK: - App Group UserDefaults
 
     /// 위젯과 메인 앱이 데이터를 공유하기 위한 공간
-    private let userDefaults = UserDefaults(suiteName: Bundle.main.infoDictionary?["AppGroupID"] as? String)
+    let userDefaults = UserDefaults(suiteName: Bundle.main.infoDictionary?["AppGroupID"] as? String)
 
     // MARK: - Event & Parameter Keys
 
-    private enum Event {
+    enum Event {
         static let addWidget = "add_widget_ios"
         static let changeWidget = "change_widget_ios"
     }
@@ -30,7 +29,7 @@ final class WidgetAnalyticsManager {
         static let restaurantAfter = "restaurant_after"
     }
 
-    private enum UserDefaultsKey {
+    enum UserDefaultsKey {
         static let widgetAdded = "pendingWidgetAddedEvent"
         static let widgetChanged = "pendingWidgetChangedEvent"
     }
@@ -68,25 +67,5 @@ final class WidgetAnalyticsManager {
         ]
 
         userDefaults?.set(changeInfo, forKey: UserDefaultsKey.widgetChanged)
-    }
-
-    // MARK: - Method to be Called from Main App
-
-    /// (메인 앱에서 호출) 기록된 위젯 이벤트가 있다면 Firebase로 전송하고 기록을 삭제합니다.
-    /// 이 파일은 위젯 타겟에도 포함되므로, PostHog 의존성 없이 Firebase만 직접 호출합니다.
-    func sendPendingEvents() {
-        // 1. 위젯 추가 이벤트 전송
-        if userDefaults?.bool(forKey: UserDefaultsKey.widgetAdded) == true {
-            Analytics.logEvent(Event.addWidget, parameters: nil)
-            userDefaults?.removeObject(forKey: UserDefaultsKey.widgetAdded)
-            print("Analytics: Logged add_widget_ios")
-        }
-
-        // 2. 위젯 변경 이벤트 전송
-        if let changeInfo = userDefaults?.dictionary(forKey: UserDefaultsKey.widgetChanged) as? [String: String] {
-            Analytics.logEvent(Event.changeWidget, parameters: changeInfo)
-            userDefaults?.removeObject(forKey: UserDefaultsKey.widgetChanged)
-            print("Analytics: Logged change_widget_ios with params \(changeInfo)")
-        }
     }
 }

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
@@ -34,10 +34,12 @@ final class LoginViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
+        logScreenView(screenID: FirebaseScreenID.Login.log3)
+
         // 로그인 화면 진입 시 로컬 데이터 초기화 (데이터 불일치 방지)
         RealmService.shared.resetDB()
-        
+
         configureFirebaseRemoteConfig()
     }
     

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/CreatorViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/CreatorViewController.swift
@@ -29,7 +29,8 @@ class CreatorViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
+        logScreenView(screenID: FirebaseScreenID.MyPage.mypage2)
         setUpAction()
         applyGradientBackground()
         view.layoutIfNeeded()

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/ProvisionViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/ProvisionViewController.swift
@@ -32,6 +32,12 @@ final class ProvisionViewController: BaseViewController {
         super.init(nibName: nil, bundle: nil)
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        logScreenView(screenID: FirebaseScreenID.MyPage.mypage5)
+    }
+
     // MARK: - Functions
 
     override func setCustomNavigationBar() {

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/ReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/ReviewViewController.swift
@@ -94,7 +94,8 @@ final class ReviewViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
+        logScreenView(screenID: FirebaseScreenID.Review.V1.review_v1_1)
         setTableView()
         setFirebaseTask()
     }

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
@@ -66,7 +66,8 @@ final class SetRateViewController: BaseViewController, UINavigationControllerDel
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
+        logScreenView(screenID: FirebaseScreenID.Review.V1.review_v1_2)
         setDelegates()
         setupInitialDataFetch()
     }

--- a/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
@@ -84,9 +84,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     /// PostHog Analytics를 구성합니다.
     private func configurePostHog() {
         #if !DEBUG
-        guard let apiKey = Bundle.main.infoDictionary?["POSTHOG_API_KEY"] as? String,
-              !apiKey.isEmpty else {
+        guard let rawValue = Bundle.main.infoDictionary?["POSTHOG_API_KEY"] as? String else {
             print("PostHog API Key를 찾을 수 없습니다.")
+            return
+        }
+
+        let apiKey = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !apiKey.isEmpty, !apiKey.contains("$(") else {
+            print("PostHog API Key가 비어 있거나 유효하지 않습니다.")
             return
         }
 

--- a/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
@@ -12,6 +12,7 @@ import Firebase
 import FirebaseMessaging
 import KakaoSDKCommon
 import NMapsMap
+import PostHog
 import RealmSwift
 
 @main
@@ -28,6 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         initializeKakaoSDK()
         setupDebugConfigurations()
         configureNaverMapAuth()
+        configurePostHog()
         TokenManager.refreshIfNeededAsync()
         UNUserNotificationCenter.current().delegate = self
 
@@ -77,6 +79,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         } else {
             print("NAVER_CLIENT_ID 못 찾음")
         }
+    }
+
+    /// PostHog Analytics를 구성합니다.
+    private func configurePostHog() {
+        guard let apiKey = Bundle.main.infoDictionary?["POSTHOG_API_KEY"] as? String,
+              !apiKey.isEmpty else {
+            print("PostHog API Key를 찾을 수 없습니다.")
+            return
+        }
+
+        let config = PostHogConfig(apiKey: apiKey)
+        config.host = "https://us.i.posthog.com"
+        config.captureApplicationLifecycleEvents = true
+        config.captureScreenViews = false
+
+        #if DEBUG
+        config.debug = true
+        #endif
+
+        PostHogSDK.shared.setup(config)
     }
 
     // MARK: - Private Methods

--- a/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
@@ -83,9 +83,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     /// PostHog Analytics를 구성합니다.
     private func configurePostHog() {
-        #if DEBUG
-        return
-        #else
+        #if !DEBUG
         guard let apiKey = Bundle.main.infoDictionary?["POSTHOG_API_KEY"] as? String,
               !apiKey.isEmpty else {
             print("PostHog API Key를 찾을 수 없습니다.")

--- a/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
@@ -83,22 +83,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
     /// PostHog Analytics를 구성합니다.
     private func configurePostHog() {
+        #if DEBUG
+        return
+        #else
         guard let apiKey = Bundle.main.infoDictionary?["POSTHOG_API_KEY"] as? String,
               !apiKey.isEmpty else {
             print("PostHog API Key를 찾을 수 없습니다.")
             return
         }
 
-        let config = PostHogConfig(apiKey: apiKey)
-        config.host = "https://us.i.posthog.com"
+        let config = PostHogConfig(apiKey: apiKey, host: "https://us.i.posthog.com")
         config.captureApplicationLifecycleEvents = true
         config.captureScreenViews = false
 
-        #if DEBUG
-        config.debug = true
-        #endif
-
         PostHogSDK.shared.setup(config)
+        #endif
     }
 
     // MARK: - Private Methods

--- a/EATSSU/App/Sources/Utility/Extension/UIViewController+.swift
+++ b/EATSSU/App/Sources/Utility/Extension/UIViewController+.swift
@@ -9,6 +9,7 @@ import UIKit.UIViewController
 
 import EATSSUDesign
 import FirebaseAnalytics
+import PostHog
 import SwiftUI // Keep SwiftUI import in case other parts of the app uses it for things unrelated to the removed toPreview function
 
 extension UIViewController {
@@ -16,6 +17,9 @@ extension UIViewController {
         Analytics.logEvent(AnalyticsEventScreenView,
                            parameters: [AnalyticsParameterScreenName: screenID,
                                        AnalyticsParameterScreenClass: String(describing: type(of: self))])
+        PostHogSDK.shared.screen(screenID, properties: [
+            "screen_class": String(describing: type(of: self))
+        ])
     }
     
     // MARK: - Custom Dialog

--- a/EATSSU/App/Sources/Utility/Extension/UIViewController+.swift
+++ b/EATSSU/App/Sources/Utility/Extension/UIViewController+.swift
@@ -8,18 +8,11 @@
 import UIKit.UIViewController
 
 import EATSSUDesign
-import FirebaseAnalytics
-import PostHog
 import SwiftUI // Keep SwiftUI import in case other parts of the app uses it for things unrelated to the removed toPreview function
 
 extension UIViewController {
     func logScreenView(screenID: String) {
-        Analytics.logEvent(AnalyticsEventScreenView,
-                           parameters: [AnalyticsParameterScreenName: screenID,
-                                       AnalyticsParameterScreenClass: String(describing: type(of: self))])
-        PostHogSDK.shared.screen(screenID, properties: [
-            "screen_class": String(describing: type(of: self))
-        ])
+        AnalyticsService.logScreen(screenID, screenClass: String(describing: type(of: self)))
     }
     
     // MARK: - Custom Dialog

--- a/EATSSU/Project.swift
+++ b/EATSSU/Project.swift
@@ -46,6 +46,7 @@ let appInfoPlist: InfoPlist = .extendingDefault(with: [
     // 사용 국가 지정
     "CFBundleDevelopmentRegion": "ko",
     "NAVER_CLIENT_ID": "$(NAVER_CLIENT_ID)",
+    "POSTHOG_API_KEY": "$(POSTHOG_API_KEY)",
 ])
 
 let widgetInfoPlist: InfoPlist = .extendingDefault(with: [
@@ -130,7 +131,8 @@ let project = Project(
                 .external(name: "KakaoSDKCommon"),
                 .external(name: "KakaoSDKTalk"),
                 .external(name: "NMapsMap"),
-                
+                .external(name: "PostHog"),
+
                 // EATSSU 내장 라이브러리
                 .project(target: "EATSSUDesign", path: .relativeToRoot("../EATSSUDesign"), condition: .none),
             ],
@@ -184,7 +186,8 @@ let project = Project(
                 .external(name: "KakaoSDKCommon"),
                 .external(name: "KakaoSDKTalk"),
                 .external(name: "NMapsMap"),
-                
+                .external(name: "PostHog"),
+
                 // EATSSU 내장 라이브러리
                 .project(target: "EATSSUDesign", path: .relativeToRoot("../EATSSUDesign"), condition: .none),
             ],

--- a/EATSSU/Project.swift
+++ b/EATSSU/Project.swift
@@ -66,7 +66,9 @@ let projectSettings: Settings = .settings(
         "DEVELOPMENT_LANGUAGE": "ko",
         "DEVELOPMENT_TEAM": "BBVZV8T99P",
         "SWIFT_CONCURRENCY": "complete",
-        "CODE_SIGN_STYLE": "Manual"
+        "CODE_SIGN_STYLE": "Manual",
+        "MARKETING_VERSION": "3.5.0",
+        "CURRENT_PROJECT_VERSION": "1"
     ],
     configurations: [
         .debug(

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9d69386e6ea6495a44e2469f723c08a7f59b16773d9d210eb24af5de456a00e4",
+  "originHash" : "7321f42fbe1130573b373a33dc7a2990171ec610b5915a14e50b70372235d0ce",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -152,6 +152,15 @@
       "state" : {
         "revision" : "be0c1f6f1964cfb07f9d819b0863f2c3f255f612",
         "version" : "4.2.0"
+      }
+    },
+    {
+      "identity" : "posthog-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PostHog/posthog-ios",
+      "state" : {
+        "revision" : "3f77915239d2c7644f55c8b513c257b8485d1c32",
+        "version" : "3.42.1"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -36,6 +36,9 @@ import PackageDescription
             
             // Naver Maps
             "NMapsMap": .framework,
+
+            // PostHog
+            "PostHog": .framework,
         ]
     )
 #endif
@@ -54,6 +57,7 @@ let package = Package(
         .package(url: "https://github.com/google/GoogleAppMeasurement", from: "11.1.0"),
         .package(url: "https://github.com/realm/realm-swift", from: "20.0.0"),
         .package(url: "https://github.com/navermaps/SPM-NMapsMap", from: "3.20.0"),
+        .package(url: "https://github.com/PostHog/posthog-ios", from: "3.0.0"),
 
     ]
 )


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #394 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

* **통합 Analytics 레이어 도입 (`AnalyticsService`)**

  * 이벤트/스크린 로깅을 `AnalyticsService`로 중앙화해서 Firebase + PostHog 동시 전송 가능
  * 기존 매니저/모듈의 직접 Firebase 호출을 전부 `AnalyticsService` 호출로 리팩토링

* **기존 FirebaseAnalytics 의존 제거**

  * 로깅은 `AnalyticsService`가 담당하도록 변경하면서 각 매니저 파일의 불필요한 `FirebaseAnalytics` import 제거

* **PostHog 연동 추가**

  * PostHog SDK 추가 및 `Info.plist`/의존성 설정 업데이트
  * `AppDelegate`에 `configurePostHog()` 구현: API Key 기반 초기화 + 앱 라이프사이클 이벤트 캡처

* **위젯 Analytics 개선**

  * `WidgetAnalyticsManager`에서 이벤트/키 enum을 외부로 노출하도록 정리
  * 위젯 이벤트 전송 로직을 extension으로 분리하고 `AnalyticsService`로 통합 로깅(Firebase/PostHog) 처리

* **스크린 뷰 로깅 강화**

  * 여러 ViewController에서 `logScreenView` 호출로 스크린 뷰 이벤트가 일관되게 기록되도록 개선

* **프로젝트 설정 업데이트**

  * 마케팅 버전(버저닝) 관련 설정 업데이트
  * 빌드 설정에 PostHog API Key 추가 (환경별 구성 지원)

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- posthog에서 테스트 완료했습니다. 
- 릴리즈 모드에서만 동작합니다.