### PR TITLE
[#384] 로그인 화면 "최근에 로그인했어요" 툴팁 기능 구현

### DIFF
--- a/EATSSU/App/Sources/Presentation/Auth/View/LastLoginTooltipView.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/View/LastLoginTooltipView.swift
@@ -1,0 +1,135 @@
+//
+//  LastLoginTooltipView.swift
+//  EATSSU
+//
+//  Created by 황상환 2026/03/05.
+//
+
+import UIKit
+
+import EATSSUDesign
+
+/// 로그인 화면에서 "최근에 로그인했어요" 말풍선 툴팁을 표시하는 뷰
+final class LastLoginTooltipView: UIView {
+
+    enum ArrowDirection {
+        /// 화살표가 아래를 가리킴 (Apple 버튼 위에 표시할 때)
+        case down
+        /// 화살표가 위를 가리킴 (Kakao 버튼 아래에 표시할 때)
+        case up
+    }
+
+    // MARK: - Constants
+
+    private enum Metric {
+        static let arrowSize = CGSize(width: 12, height: 6)
+        static let cornerRadius: CGFloat = 8
+        static let horizontalPadding: CGFloat = 16
+        static let verticalPadding: CGFloat = 12
+        static let fontSize: CGFloat = 12
+    }
+
+    // MARK: - Properties
+
+    private let arrowDirection: ArrowDirection
+
+    private let label: UILabel = {
+        let label = UILabel()
+        label.text = TextLiteral.Auth.lastLoginTooltip
+        label.textColor = .white
+        label.font = EATSSUDesignFontFamily.Pretendard.medium.font(size: Metric.fontSize)
+        label.textAlignment = .center
+        return label
+    }()
+
+    // MARK: - Init
+
+    init(arrowDirection: ArrowDirection) {
+        self.arrowDirection = arrowDirection
+        super.init(frame: .zero)
+        backgroundColor = .clear
+        addSubview(label)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        let arrowHeight = Metric.arrowSize.height
+        let labelY: CGFloat
+        switch arrowDirection {
+        case .up:
+            labelY = arrowHeight
+        case .down:
+            labelY = 0
+        }
+
+        label.frame = CGRect(
+            x: Metric.horizontalPadding,
+            y: labelY + Metric.verticalPadding,
+            width: bounds.width - Metric.horizontalPadding * 2,
+            height: bounds.height - arrowHeight - Metric.verticalPadding * 2
+        )
+    }
+
+    override var intrinsicContentSize: CGSize {
+        let labelSize = label.intrinsicContentSize
+        let width = labelSize.width + Metric.horizontalPadding * 2
+        let height = labelSize.height + Metric.verticalPadding * 2 + Metric.arrowSize.height
+        return CGSize(width: width, height: height)
+    }
+
+    // MARK: - Drawing
+
+    override func draw(_ rect: CGRect) {
+        guard let context = UIGraphicsGetCurrentContext() else { return }
+
+        let arrowSize = Metric.arrowSize
+        let cornerRadius = Metric.cornerRadius
+        let fillColor = UIColor.gray700
+
+        context.setFillColor(fillColor.cgColor)
+
+        let bubbleRect: CGRect
+        switch arrowDirection {
+        case .up:
+            bubbleRect = CGRect(x: 0, y: arrowSize.height, width: rect.width, height: rect.height - arrowSize.height)
+        case .down:
+            bubbleRect = CGRect(x: 0, y: 0, width: rect.width, height: rect.height - arrowSize.height)
+        }
+
+        let bubblePath = UIBezierPath(roundedRect: bubbleRect, cornerRadius: cornerRadius)
+        bubblePath.fill()
+
+        // 화살표 그리기
+        let arrowPath = UIBezierPath()
+        let arrowCenterX = rect.width / 2
+
+        switch arrowDirection {
+        case .up:
+            let arrowTip = CGPoint(x: arrowCenterX, y: 0)
+            let arrowLeft = CGPoint(x: arrowCenterX - arrowSize.width / 2, y: arrowSize.height)
+            let arrowRight = CGPoint(x: arrowCenterX + arrowSize.width / 2, y: arrowSize.height)
+            arrowPath.move(to: arrowTip)
+            arrowPath.addLine(to: arrowRight)
+            arrowPath.addLine(to: arrowLeft)
+            arrowPath.close()
+        case .down:
+            let arrowTip = CGPoint(x: arrowCenterX, y: rect.height)
+            let arrowLeft = CGPoint(x: arrowCenterX - arrowSize.width / 2, y: rect.height - arrowSize.height)
+            let arrowRight = CGPoint(x: arrowCenterX + arrowSize.width / 2, y: rect.height - arrowSize.height)
+            arrowPath.move(to: arrowTip)
+            arrowPath.addLine(to: arrowRight)
+            arrowPath.addLine(to: arrowLeft)
+            arrowPath.close()
+        }
+
+        arrowPath.fill()
+    }
+}

--- a/EATSSU/App/Sources/Presentation/Auth/View/LastLoginTooltipView.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/View/LastLoginTooltipView.swift
@@ -48,6 +48,8 @@ final class LastLoginTooltipView: UIView {
         self.arrowDirection = arrowDirection
         super.init(frame: .zero)
         backgroundColor = .clear
+        isOpaque = false
+        contentMode = .redraw
         addSubview(label)
     }
 

--- a/EATSSU/App/Sources/Presentation/Auth/View/LoginView.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/View/LoginView.swift
@@ -86,13 +86,13 @@ final class LoginView: BaseUIView {
     // MARK: - Tooltip
 
     /// 마지막 로그인 제공자에 따라 말풍선 툴팁을 표시한다.
-    func showLastLoginTooltip(provider: String) {
+    func showLastLoginTooltip(provider: UserInfo.AccountType) {
         lastLoginTooltipView?.removeFromSuperview()
 
         let tooltipSpacing: CGFloat = 4
 
         switch provider {
-        case "Apple":
+        case .apple:
             let tooltip = LastLoginTooltipView(arrowDirection: .down)
             addSubview(tooltip)
             tooltip.snp.makeConstraints {
@@ -101,7 +101,7 @@ final class LoginView: BaseUIView {
             }
             lastLoginTooltipView = tooltip
 
-        case "Kakao":
+        case .kakao:
             let tooltip = LastLoginTooltipView(arrowDirection: .up)
             addSubview(tooltip)
             tooltip.snp.makeConstraints {
@@ -109,9 +109,6 @@ final class LoginView: BaseUIView {
                 $0.top.equalTo(kakaoLoginButton.snp.bottom).offset(tooltipSpacing)
             }
             lastLoginTooltipView = tooltip
-
-        default:
-            break
         }
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissTooltip))

--- a/EATSSU/App/Sources/Presentation/Auth/View/LoginView.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/View/LoginView.swift
@@ -44,6 +44,8 @@ final class LoginView: BaseUIView {
         return button
     }()
 
+    private var lastLoginTooltipView: LastLoginTooltipView?
+
     override func configureUI() {
         addSubviews(
             logoImage,
@@ -79,5 +81,49 @@ final class LoginView: BaseUIView {
             $0.centerX.equalToSuperview()
             $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(30)
         }
+    }
+
+    // MARK: - Tooltip
+
+    /// 마지막 로그인 제공자에 따라 말풍선 툴팁을 표시한다.
+    func showLastLoginTooltip(provider: String) {
+        lastLoginTooltipView?.removeFromSuperview()
+
+        let tooltipSpacing: CGFloat = 4
+
+        switch provider {
+        case "Apple":
+            let tooltip = LastLoginTooltipView(arrowDirection: .down)
+            addSubview(tooltip)
+            tooltip.snp.makeConstraints {
+                $0.centerX.equalTo(appleLoginButton)
+                $0.bottom.equalTo(appleLoginButton.snp.top).offset(-tooltipSpacing)
+            }
+            lastLoginTooltipView = tooltip
+
+        case "Kakao":
+            let tooltip = LastLoginTooltipView(arrowDirection: .up)
+            addSubview(tooltip)
+            tooltip.snp.makeConstraints {
+                $0.centerX.equalTo(kakaoLoginButton)
+                $0.top.equalTo(kakaoLoginButton.snp.bottom).offset(tooltipSpacing)
+            }
+            lastLoginTooltipView = tooltip
+
+        default:
+            break
+        }
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissTooltip))
+        lastLoginTooltipView?.addGestureRecognizer(tapGesture)
+    }
+
+    @objc private func dismissTooltip() {
+        UIView.animate(withDuration: 0.2, animations: {
+            self.lastLoginTooltipView?.alpha = 0
+        }, completion: { _ in
+            self.lastLoginTooltipView?.removeFromSuperview()
+            self.lastLoginTooltipView = nil
+        })
     }
 }

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
@@ -41,6 +41,7 @@ final class LoginViewController: BaseViewController {
         RealmService.shared.resetDB()
 
         configureFirebaseRemoteConfig()
+        showLastLoginTooltipIfNeeded()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -84,6 +85,13 @@ final class LoginViewController: BaseViewController {
 
     private func configureFirebaseRemoteConfig() {
         FirebaseRemoteConfig.shared.fetchIsVacationPeriod()
+    }
+
+    private func showLastLoginTooltipIfNeeded() {
+        guard let provider = UserDefaults.standard.string(forKey: TextLiteral.Auth.lastLoginProviderKey) else {
+            return
+        }
+        loginView.showLastLoginTooltip(provider: provider)
     }
 
     private func hasStoredToken() -> Bool {
@@ -229,6 +237,7 @@ extension LoginViewController {
                 storeTokensAndPrintDebugLogs(accessToken: signData.accessToken,
                                             refreshToken: signData.refreshToken)
                 _ = UserInfoManager.shared.createUserInfo(accountType: .kakao)
+                UserDefaults.standard.set("Kakao", forKey: TextLiteral.Auth.lastLoginProviderKey)
                 getMyInfo()
                 
             case .failure(let error):
@@ -257,6 +266,7 @@ extension LoginViewController {
                 storeTokensAndPrintDebugLogs(accessToken: signData.accessToken,
                                             refreshToken: signData.refreshToken)
                 _ = UserInfoManager.shared.createUserInfo(accountType: .apple)
+                UserDefaults.standard.set("Apple", forKey: TextLiteral.Auth.lastLoginProviderKey)
                 getMyInfo()
                 
             case .failure(let error):

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
@@ -88,7 +88,8 @@ final class LoginViewController: BaseViewController {
     }
 
     private func showLastLoginTooltipIfNeeded() {
-        guard let provider = UserDefaults.standard.string(forKey: TextLiteral.Auth.lastLoginProviderKey) else {
+        guard let providerRaw = UserDefaults.standard.string(forKey: TextLiteral.Auth.lastLoginProviderKey),
+              let provider = UserInfo.AccountType(rawValue: providerRaw) else {
             return
         }
         loginView.showLastLoginTooltip(provider: provider)
@@ -237,7 +238,7 @@ extension LoginViewController {
                 storeTokensAndPrintDebugLogs(accessToken: signData.accessToken,
                                             refreshToken: signData.refreshToken)
                 _ = UserInfoManager.shared.createUserInfo(accountType: .kakao)
-                UserDefaults.standard.set("Kakao", forKey: TextLiteral.Auth.lastLoginProviderKey)
+                UserDefaults.standard.set(UserInfo.AccountType.kakao.rawValue, forKey: TextLiteral.Auth.lastLoginProviderKey)
                 getMyInfo()
                 
             case .failure(let error):
@@ -266,7 +267,7 @@ extension LoginViewController {
                 storeTokensAndPrintDebugLogs(accessToken: signData.accessToken,
                                             refreshToken: signData.refreshToken)
                 _ = UserInfoManager.shared.createUserInfo(accountType: .apple)
-                UserDefaults.standard.set("Apple", forKey: TextLiteral.Auth.lastLoginProviderKey)
+                UserDefaults.standard.set(UserInfo.AccountType.apple.rawValue, forKey: TextLiteral.Auth.lastLoginProviderKey)
                 getMyInfo()
                 
             case .failure(let error):

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
@@ -88,11 +88,18 @@ final class LoginViewController: BaseViewController {
     }
 
     private func showLastLoginTooltipIfNeeded() {
-        guard let providerRaw = UserDefaults.standard.string(forKey: TextLiteral.Auth.lastLoginProviderKey),
-              let provider = UserInfo.AccountType(rawValue: providerRaw) else {
+        let defaults = UserDefaults.standard
+        let key = TextLiteral.Auth.lastLoginProviderKey
+
+        guard let providerRaw = defaults.string(forKey: key) else {
             return
         }
-        loginView.showLastLoginTooltip(provider: provider)
+
+        if let provider = UserInfo.AccountType(rawValue: providerRaw) {
+            loginView.showLastLoginTooltip(provider: provider)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
     }
 
     private func hasStoredToken() -> Bool {

--- a/EATSSU/App/Sources/Utility/Literal/TextLiteral.swift
+++ b/EATSSU/App/Sources/Utility/Literal/TextLiteral.swift
@@ -89,6 +89,12 @@ enum TextLiteral {
         /// "둘러보기"
         static let lookingWithNoSignIn: String = "둘러보기"
 
+        /// UserDefaults key for last login provider
+        static let lastLoginProviderKey: String = "lastLoginProvider"
+
+        /// "최근에 로그인했어요"
+        static let lastLoginTooltip: String = "최근에 로그인했어요"
+
         /// LoginVC - "카카오톡으로 생성된 계정입니다."
         static let kakaoAccount: String = "카카오톡으로 생성된 계정입니다."
 


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #384 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- LastLoginTooltipView 말풍선 뷰 생성 (화살표 방향 up/down 지원)
- 로그인 성공 시 UserDefaults에 마지막 로그인 방식 저장
- 로그인 화면 진입 시 저장된 정보로 툴팁 표시
- 툴팁 터치 시 페이드아웃 dismiss 처리

<img width="250" alt="image" src="https://github.com/user-attachments/assets/a2b6cb4f-6a4f-40c8-b86a-78d76321e2c0" />


### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 무조건 한번은 로그인을 해야 동작하는 단점이 있습니다.