### PR TITLE
[#399] 메인탭 레이아웃 수정

### DIFF
--- a/EATSSU/App/Sources/Presentation/Auth/View/DropDownView.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/View/DropDownView.swift
@@ -90,7 +90,7 @@ final class DropDownView: BaseUIView {
 
         // 드롭다운 테이블 생성
         let tableView = UITableView()
-        tableView.layer.cornerRadius = 12
+        tableView.layer.cornerRadius = 10
         tableView.layer.borderWidth = 1
         tableView.layer.borderColor = UIColor.gray300.cgColor
         tableView.layer.shadowColor = UIColor.black.cgColor
@@ -168,7 +168,7 @@ final class DropDownView: BaseUIView {
         config.titleAlignment = .leading
 
         button.configuration = config
-        button.layer.cornerRadius = 12
+        button.layer.cornerRadius = 10
         button.layer.borderWidth = 1
         button.layer.borderColor = UIColor.gray300.cgColor
         button.contentHorizontalAlignment = .leading

--- a/EATSSU/App/Sources/Presentation/Home/View/HomeRestaurantView.swift
+++ b/EATSSU/App/Sources/Presentation/Home/View/HomeRestaurantView.swift
@@ -16,7 +16,7 @@ final class HomeRestaurantView: BaseUIView {
     // MARK: - UI Components
 
     lazy var restaurantTableView: UITableView = {
-        let tableView = UITableView(frame: .zero, style: .insetGrouped)
+        let tableView = UITableView(frame: .zero, style: .grouped)
         tableView.separatorStyle = .none
         tableView.contentInset = .zero
         tableView.backgroundColor = .gray100

--- a/EATSSU/App/Sources/Presentation/Home/View/RestaurantTableView/RestaurantMenuGroupCell.swift
+++ b/EATSSU/App/Sources/Presentation/Home/View/RestaurantTableView/RestaurantMenuGroupCell.swift
@@ -20,6 +20,7 @@ final class RestaurantMenuGroupCell: BaseTableViewCell {
         view.layer.cornerRadius = 12
         view.layer.borderWidth = 1
         view.layer.borderColor = UIColor.gray200.cgColor
+        view.layer.masksToBounds = true
         view.backgroundColor = .white
         return view
     }()
@@ -51,6 +52,8 @@ final class RestaurantMenuGroupCell: BaseTableViewCell {
     override func configureUI() {
         self.selectionStyle = .none
         self.selectedBackgroundView = UIView()
+        self.backgroundColor = .clear
+        contentView.backgroundColor = .clear
         contentView.addSubview(wrapperView)
         wrapperView.addSubviews(titleView, emptyLabel, menuStackView)
 
@@ -60,7 +63,8 @@ final class RestaurantMenuGroupCell: BaseTableViewCell {
     // 오토레이아웃 설정
     override func setLayout() {
         wrapperView.snp.makeConstraints {
-            $0.top.leading.trailing.equalToSuperview()
+            $0.top.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(20)
             $0.bottom.equalToSuperview().priority(UILayoutPriority.defaultHigh) 
         }
 
@@ -70,8 +74,8 @@ final class RestaurantMenuGroupCell: BaseTableViewCell {
 
         emptyLabel.snp.makeConstraints {
             $0.top.equalTo(titleView.snp.bottom).offset(16)
-            $0.horizontalEdges.equalToSuperview().inset(12)
-            $0.bottom.equalToSuperview().inset(16)
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(22)
         }
 
         menuStackView.snp.makeConstraints {

--- a/EATSSU/App/Sources/Presentation/Home/View/RestaurantTableView/RestaurantTableViewHeader.swift
+++ b/EATSSU/App/Sources/Presentation/Home/View/RestaurantTableView/RestaurantTableViewHeader.swift
@@ -54,7 +54,7 @@ class RestaurantTableViewHeader: BaseTableViewHeaderView {
 
     func setLayout() {
         stackView.snp.makeConstraints {
-            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.horizontalEdges.equalToSuperview().inset(22)
             $0.centerY.equalToSuperview()
         }
         titleLabel.snp.makeConstraints {

--- a/EATSSU/App/Sources/Presentation/Home/View/RestaurantTableView/RestaurantTableViewHeader.swift
+++ b/EATSSU/App/Sources/Presentation/Home/View/RestaurantTableView/RestaurantTableViewHeader.swift
@@ -54,7 +54,7 @@ class RestaurantTableViewHeader: BaseTableViewHeaderView {
 
     func setLayout() {
         stackView.snp.makeConstraints {
-            $0.horizontalEdges.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(20)
             $0.centerY.equalToSuperview()
         }
         titleLabel.snp.makeConstraints {


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #399 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

  - DropDownView cornerRadius를 10으로 통일 (ESTextField와 동일하게)
  - 식당 카드 테두리 라운드 잘림 현상 수정 (테이블뷰 스타일 insetGrouped → grouped 변경)
  - 식당 카드 wrapperView에 좌우 20pt inset 및 배경 투명 처리
  - 섹션 헤더 좌우 여백 22pt 추가
  - 영업시간 안내 텍스트 중앙 정렬 및 하단 여백 조정

<img width="346" height="472" alt="image" src="https://github.com/user-attachments/assets/97bb34f0-8d79-4a3e-834e-a93d5ba76b8b" />

<img width="340" height="280" alt="image" src="https://github.com/user-attachments/assets/acf2c11b-dd2a-412c-9d92-2ad18d9ddf34" />

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- x