### PR TITLE
[#405] PostHog 누락 이벤트 추가 및 신규 이벤트 추적 적용

### DIFF
--- a/EATSSU/App/Sources/Data/Firebase/HomeAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/HomeAnalyticsManager.swift
@@ -20,7 +20,7 @@ final class HomeAnalyticsManager {
     private enum Event {
         static let clickRestaurantInfo = "click_restaurant_info"
         static let selectMealTime = "select_mealtime"
-        static let selectDay = "select_day"
+        static let selectDay = "click_day"
         static let clickMenu = "click_menu"
     }
 

--- a/EATSSU/App/Sources/Data/Firebase/HomeAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/HomeAnalyticsManager.swift
@@ -20,7 +20,7 @@ final class HomeAnalyticsManager {
     private enum Event {
         static let clickRestaurantInfo = "click_restaurant_info"
         static let selectMealTime = "select_mealtime"
-        static let selectDay = "click_day"
+        static let selectDay = "select_day"
         static let clickMenu = "click_menu"
     }
 

--- a/EATSSU/App/Sources/Data/Firebase/MapAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/MapAnalyticsManager.swift
@@ -17,7 +17,6 @@ final class MapAnalyticsManager {
 
     private enum Event {
         static let clickMap = "click_map"
-        static let clickMapAll = "click_map_all"
         static let clickMapMine = "click_map_mine"
         static let clickPartnerRestaurant = "click_partner_restaurant"
     }
@@ -38,14 +37,7 @@ final class MapAnalyticsManager {
     }
 
     /**
-     #2 지도 화면에서 '전체' 버튼을 클릭했을 때 호출
-     */
-    func logClickMapAll() {
-        AnalyticsService.logEvent(Event.clickMapAll)
-    }
-
-    /**
-     #3 지도 화면에서 '내 제휴' (또는 학과명) 버튼을 클릭했을 때 호출
+     #2 지도 화면에서 '내 제휴' (또는 학과명) 버튼을 클릭했을 때 호출
      - Parameter collegeId: 사용자의 단과대 ID
      - Parameter majorId: 사용자의 학과 ID
      */

--- a/EATSSU/App/Sources/Data/Firebase/MapAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/MapAnalyticsManager.swift
@@ -17,6 +17,7 @@ final class MapAnalyticsManager {
 
     private enum Event {
         static let clickMap = "click_map"
+        static let clickMapAll = "click_map_all"
         static let clickMapMine = "click_map_mine"
         static let clickPartnerRestaurant = "click_partner_restaurant"
     }
@@ -37,7 +38,14 @@ final class MapAnalyticsManager {
     }
 
     /**
-     #2 지도 화면에서 '내 제휴' (또는 학과명) 버튼을 클릭했을 때 호출
+     #2 지도 화면에서 '전체' 버튼을 클릭했을 때 호출
+     */
+    func logClickMapAll() {
+        AnalyticsService.logEvent(Event.clickMapAll)
+    }
+
+    /**
+     #3 지도 화면에서 '내 제휴' (또는 학과명) 버튼을 클릭했을 때 호출
      - Parameter collegeId: 사용자의 단과대 ID
      - Parameter majorId: 사용자의 학과 ID
      */

--- a/EATSSU/App/Sources/Data/Firebase/ReviewAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/ReviewAnalyticsManager.swift
@@ -16,8 +16,8 @@ final class ReviewAnalyticsManager {
     // MARK: - Event & Parameter Keys
 
     private enum Event {
-        static let writeReview = "write_review_v1"
-        static let completeReview = "complete_review_v1"
+        static let writeReview = "write_review_v2"
+        static let completeReview = "complete_review_v2"
     }
 
     private enum Parameter {

--- a/EATSSU/App/Sources/Data/Firebase/ReviewAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/ReviewAnalyticsManager.swift
@@ -23,7 +23,7 @@ final class ReviewAnalyticsManager {
     private enum Parameter {
         static let photoAttached = "photo_attached"
         static let rating = "rating"
-        static let selection = "selection"
+        static let likes = "likes"
     }
 
     // MARK: - Logging Methods
@@ -41,11 +41,11 @@ final class ReviewAnalyticsManager {
      - Parameter rating: 사용자가 부여한 메인 별점 (1~5)
      - Parameter selection: 사용자가 한 번에 리뷰를 작성하는 메뉴의 총 개수
      */
-    func logCompleteReviewV1(photoAttached: Int, rating: Int, selection: Int) {
+    func logCompleteReviewV1(photoAttached: Int, rating: Int, likes: Int) {
         AnalyticsService.logEvent(Event.completeReview, parameters: [
             Parameter.photoAttached: photoAttached,
             Parameter.rating: rating,
-            Parameter.selection: selection
+            Parameter.likes: likes
         ])
     }
 }

--- a/EATSSU/App/Sources/Data/Firebase/WidgetAnalyticsManager+SendEvents.swift
+++ b/EATSSU/App/Sources/Data/Firebase/WidgetAnalyticsManager+SendEvents.swift
@@ -11,10 +11,15 @@ extension WidgetAnalyticsManager {
     func sendPendingEvents() {
         // 1. 위젯 추가 이벤트 전송
         if userDefaults?.bool(forKey: UserDefaultsKey.widgetAdded) == true {
-            AnalyticsService.logEvent(Event.addWidget)
+            var parameters: [String: Any] = [:]
+            if let restaurant = userDefaults?.string(forKey: UserDefaultsKey.widgetAddedRestaurant) {
+                parameters["restaurants"] = restaurant
+            }
+            AnalyticsService.logEvent(Event.addWidget, parameters: parameters)
             userDefaults?.removeObject(forKey: UserDefaultsKey.widgetAdded)
+            userDefaults?.removeObject(forKey: UserDefaultsKey.widgetAddedRestaurant)
             #if DEBUG
-            print("Analytics: Logged add_widget_ios")
+            print("Analytics: Logged add_widget with params \(parameters)")
             #endif
         }
 
@@ -23,7 +28,7 @@ extension WidgetAnalyticsManager {
             AnalyticsService.logEvent(Event.changeWidget, parameters: changeInfo)
             userDefaults?.removeObject(forKey: UserDefaultsKey.widgetChanged)
             #if DEBUG
-            print("Analytics: Logged change_widget_ios with params \(changeInfo)")
+            print("Analytics: Logged change_widget with params \(changeInfo)")
             #endif
         }
     }

--- a/EATSSU/App/Sources/Data/Firebase/WidgetAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/WidgetAnalyticsManager.swift
@@ -31,17 +31,19 @@ final class WidgetAnalyticsManager {
     // MARK: - Event & Parameter Keys
 
     enum Event {
-        static let addWidget = "add_widget_ios"
-        static let changeWidget = "change_widget_ios"
+        static let addWidget = "add_widget"
+        static let changeWidget = "change_widget"
     }
 
     private enum Parameter {
+        static let restaurants = "restaurants"
         static let restaurantBefore = "restaurant_before"
         static let restaurantAfter = "restaurant_after"
     }
 
     enum UserDefaultsKey {
         static let widgetAdded = "pendingWidgetAddedEvent"
+        static let widgetAddedRestaurant = "pendingWidgetAddedRestaurant"
         static let widgetChanged = "pendingWidgetChangedEvent"
     }
 
@@ -58,8 +60,12 @@ final class WidgetAnalyticsManager {
     // MARK: - Methods to be Called from Widget Extension
 
     /// (위젯에서 호출) 사용자가 위젯을 추가했을 때, 이벤트를 기록합니다.
-    func recordWidgetAdded() {
+    /// - Parameter restaurant: 위젯에 설정된 식당 이름 (한글)
+    func recordWidgetAdded(restaurant: String) {
         userDefaults?.set(true, forKey: UserDefaultsKey.widgetAdded)
+        if let paramValue = restaurantNameMap[restaurant] {
+            userDefaults?.set(paramValue, forKey: UserDefaultsKey.widgetAddedRestaurant)
+        }
     }
 
     /// (위젯에서 호출) 사용자가 위젯의 식당을 변경했을 때, 이전/이후 정보를 기록합니다.

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
@@ -128,6 +128,7 @@ final class LoginViewController: BaseViewController {
                     departmentId: info.departmentId,
                     departmentName: info.departmentName
                 )
+
             }
             changeIntoHomeViewController()
         } else {
@@ -150,6 +151,8 @@ final class LoginViewController: BaseViewController {
 
     @objc
     private func kakaoLoginButtonDidTapped() {
+        AnalyticsService.logEvent("click_login", parameters: ["method": "kakao"])
+
         // 카카오톡이 설치되어 있으면 앱을 통해 로그인 시도
         if UserApi.isKakaoTalkLoginAvailable() {
             UserApi.shared.loginWithKakaoTalk { [weak self] _, error in
@@ -180,11 +183,13 @@ final class LoginViewController: BaseViewController {
 
     @objc
     private func appleLoginButtonDidTapped() {
+        AnalyticsService.logEvent("click_login", parameters: ["method": "apple"])
         appleLoginRequest()
     }
 
     @objc
     private func lookingWithNoSignInButtonDidTapped() {
+        AnalyticsService.logEvent("click_login", parameters: ["method": "guest"])
         changeIntoHomeViewController()
     }
 }
@@ -246,6 +251,7 @@ extension LoginViewController {
                                             refreshToken: signData.refreshToken)
                 _ = UserInfoManager.shared.createUserInfo(accountType: .kakao)
                 UserDefaults.standard.set(UserInfo.AccountType.kakao.rawValue, forKey: TextLiteral.Auth.lastLoginProviderKey)
+                AnalyticsService.logEvent("complete_login", parameters: ["method": "kakao"])
                 getMyInfo()
                 
             case .failure(let error):
@@ -275,6 +281,7 @@ extension LoginViewController {
                                             refreshToken: signData.refreshToken)
                 _ = UserInfoManager.shared.createUserInfo(accountType: .apple)
                 UserDefaults.standard.set(UserInfo.AccountType.apple.rawValue, forKey: TextLiteral.Auth.lastLoginProviderKey)
+                AnalyticsService.logEvent("complete_login", parameters: ["method": "apple"])
                 getMyInfo()
                 
             case .failure(let error):

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/SetNickNameViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/SetNickNameViewController.swift
@@ -10,8 +10,6 @@ import Combine
 
 import Moya
 
-import FirebaseAnalytics
-
 import EATSSUDesign
 
 enum SetNickNameSource {

--- a/EATSSU/App/Sources/Presentation/Home/ViewController/HomeViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Home/ViewController/HomeViewController.swift
@@ -8,7 +8,6 @@
 import UIKit
 import Combine
 
-import FirebaseAnalytics
 import Moya
 import SnapKit
 

--- a/EATSSU/App/Sources/Presentation/Home/ViewController/RestaurantInfoViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Home/ViewController/RestaurantInfoViewController.swift
@@ -8,7 +8,6 @@
 import SnapKit
 
 import Moya
-import FirebaseAnalytics
 
 final class RestaurantInfoViewController: BaseViewController {
     // MARK: - UI Components

--- a/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController+Marker.swift
+++ b/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController+Marker.swift
@@ -147,6 +147,15 @@ extension MainMapViewController {
     
     /// 제휴점 상세 바텀시트 표시
     func showPartnershipDetail(for partnership: PartnershipDTO) {
+        let partnerId = partnership.partnershipInfos.first?.id
+        if let partnerId = partnerId {
+            MapAnalyticsManager.shared.logClickPartnerRestaurant(
+                collegeId: currentCollegeId,
+                majorId: currentDepartmentId,
+                partnerId: partnerId
+            )
+        }
+
         let detailVC = PartnershipDetailSheetViewController(
             storeName: partnership.storeName,
             restaurantType: partnership.restaurantType,

--- a/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController+Marker.swift
+++ b/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController+Marker.swift
@@ -147,14 +147,11 @@ extension MainMapViewController {
     
     /// 제휴점 상세 바텀시트 표시
     func showPartnershipDetail(for partnership: PartnershipDTO) {
-        let partnerId = partnership.partnershipInfos.first?.id
-        if let partnerId = partnerId {
-            MapAnalyticsManager.shared.logClickPartnerRestaurant(
-                collegeId: currentCollegeId,
-                majorId: currentDepartmentId,
-                partnerId: partnerId
-            )
-        }
+        MapAnalyticsManager.shared.logClickPartnerRestaurant(
+            collegeId: currentCollegeId,
+            majorId: currentDepartmentId,
+            partnerId: partnership.partnershipInfos.first?.id ?? -1
+        )
 
         let detailVC = PartnershipDetailSheetViewController(
             storeName: partnership.storeName,

--- a/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController.swift
@@ -10,7 +10,7 @@ import CoreLocation
 
 import NMapsMap
 import Moya
-import FirebaseAnalytics
+
 
 import EATSSUDesign
 
@@ -112,8 +112,9 @@ final class MainMapViewController: BaseViewController {
 
     @objc private func didTapWhole() {
         guard currentMapMode != .all else { return }
-        
+
         currentMapMode = .all
+        MapAnalyticsManager.shared.logClickMapAll()
         setInitialCameraPosition(animated: true)
         root.selectWhole(true)
         fetchPartnerships()

--- a/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController.swift
@@ -114,7 +114,6 @@ final class MainMapViewController: BaseViewController {
         guard currentMapMode != .all else { return }
 
         currentMapMode = .all
-        MapAnalyticsManager.shared.logClickMapAll()
         setInitialCameraPosition(animated: true)
         root.selectWhole(true)
         fetchPartnerships()

--- a/EATSSU/App/Sources/Presentation/Map/ViewController/NoDepartmentSheetViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Map/ViewController/NoDepartmentSheetViewController.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 import SnapKit
-import FirebaseAnalytics
 
 import EATSSUDesign
 

--- a/EATSSU/App/Sources/Presentation/Map/ViewController/PartnershipDetailSheetViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Map/ViewController/PartnershipDetailSheetViewController.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 import SnapKit
-import FirebaseAnalytics
 
 import EATSSUDesign
 

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/CreatorViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/CreatorViewController.swift
@@ -92,13 +92,11 @@ class CreatorViewController: BaseViewController {
 
     /// @eatssu_official 인스타그램 연결 동작
     @objc private func openInstagram() {
-        AnalyticsService.logEvent("click_creator_link", parameters: ["type": "instagram"])
         open(urlString: URLConstants.instagram)
     }
 
     /// eatssu 랜딩페이지 연결 동작
     @objc private func nextCreatorsImageTapped() {
-        AnalyticsService.logEvent("click_creator_link", parameters: ["type": "landing_page"])
         open(urlString: URLConstants.landingPage)
     }
 }

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/CreatorViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/CreatorViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 
 // External Module
 import SnapKit
-import FirebaseAnalytics
 
 import EATSSUDesign
 
@@ -93,11 +92,13 @@ class CreatorViewController: BaseViewController {
 
     /// @eatssu_official 인스타그램 연결 동작
     @objc private func openInstagram() {
+        AnalyticsService.logEvent("click_creator_link", parameters: ["type": "instagram"])
         open(urlString: URLConstants.instagram)
     }
 
     /// eatssu 랜딩페이지 연결 동작
     @objc private func nextCreatorsImageTapped() {
+        AnalyticsService.logEvent("click_creator_link", parameters: ["type": "landing_page"])
         open(urlString: URLConstants.landingPage)
     }
 }

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -99,7 +99,6 @@ final class MyPageViewController: BaseViewController {
         let fixAction = UIAlertAction(title: TextLiteral.MyPage.logout,
                                       style: .default,
                                       handler: { _ in
-                                          AnalyticsService.logEvent("click_logout")
                                           RealmService.shared.resetDB()
 
                                           let loginViewController = LoginViewController()

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -8,7 +8,6 @@
 import UIKit
 import WebKit
 
-import FirebaseAnalytics
 import KakaoSDKCommon
 import KakaoSDKTalk
 import Moya
@@ -76,6 +75,7 @@ final class MyPageViewController: BaseViewController {
     
     @objc
     private func userWithdrawButtonTapped() {
+        AnalyticsService.logEvent("click_mypage_menu", parameters: ["menu": "withdraw"])
         let userWithdrawViewController = UserWithdrawViewController(nickName: nickName)
         navigationController?.pushViewController(userWithdrawViewController, animated: true)
     }
@@ -99,6 +99,7 @@ final class MyPageViewController: BaseViewController {
         let fixAction = UIAlertAction(title: TextLiteral.MyPage.logout,
                                       style: .default,
                                       handler: { _ in
+                                          AnalyticsService.logEvent("click_logout")
                                           RealmService.shared.resetDB()
 
                                           let loginViewController = LoginViewController()
@@ -185,21 +186,25 @@ extension MyPageViewController: UITableViewDelegate {
         switch indexPath.row {
         // "푸시 알림 설정" 스위치 토글
         case MyPageLabels.NotificationSetting.rawValue:
+            AnalyticsService.logEvent("click_mypage_menu", parameters: ["menu": "notification_setting"])
             handleNotificationSettingToggle(at: indexPath)
-            
+
         // "내 정보" 스크린으로 이동
         case MyPageLabels.MyInfo.rawValue:
+            AnalyticsService.logEvent("click_mypage_menu", parameters: ["menu": "my_info"])
             let setNickNameVC = SetNickNameViewController()
             setNickNameVC.source = .signup
             navigationController?.pushViewController(setNickNameVC, animated: true)
 
         // "내 리뷰" 스크린으로 이동
         case MyPageLabels.MyReview.rawValue:
+            AnalyticsService.logEvent("click_mypage_menu", parameters: ["menu": "my_review"])
             let myReviewViewController = MyReviewViewController(nickname: nickName)
             navigationController?.pushViewController(myReviewViewController, animated: true)
 
         // "문의하기" 스크린으로 이동
         case MyPageLabels.Inquiry.rawValue:
+            AnalyticsService.logEvent("click_mypage_menu", parameters: ["menu": "inquiry"])
             TalkApi.shared.chatChannel(channelPublicId: TextLiteral.KakaoChannel.id) { [weak self] error in
                 if error != nil {
                     if let kakaoChannelLink = URL(string: "http://pf.kakao.com/\(TextLiteral.KakaoChannel.id)") {
@@ -218,18 +223,21 @@ extension MyPageViewController: UITableViewDelegate {
 
         // "서비스 이용약관" 스크린으로 이동
         case MyPageLabels.TermsOfUse.rawValue:
+            AnalyticsService.logEvent("click_mypage_menu", parameters: ["menu": "terms_of_use"])
             let provisionViewController = ProvisionViewController(agreementType: .termsOfService)
             provisionViewController.navigationTitle = TextLiteral.MyPage.termsOfUse
             navigationController?.pushViewController(provisionViewController, animated: true)
 
         // "개인정보 이용약관" 스크린으로 이동
         case MyPageLabels.PrivacyTermsOfUse.rawValue:
+            AnalyticsService.logEvent("click_mypage_menu", parameters: ["menu": "privacy_policy"])
             let provisionViewController = ProvisionViewController(agreementType: .privacyPolicy)
             provisionViewController.navigationTitle = TextLiteral.MyPage.privacyTermsOfUse
             navigationController?.pushViewController(provisionViewController, animated: true)
 
         // "만든사람들" 스크린으로 이동
         case MyPageLabels.Creator.rawValue:
+            AnalyticsService.logEvent("click_mypage_menu", parameters: ["menu": "creator"])
             let creatorViewController = CreatorViewController()
             navigationController?.pushViewController(creatorViewController, animated: true)
 

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyReviewViewController.swift
@@ -9,7 +9,6 @@ import UIKit
 
 import Moya
 import SnapKit
-import FirebaseAnalytics
 
 final class MyReviewViewController: BaseViewController {
     override var shouldHideTabBar: Bool { true }

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/UserWithdrawViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/UserWithdrawViewController.swift
@@ -142,7 +142,6 @@ extension UserWithdrawViewController {
         ) { result in
             switch result {
             case .success:
-                AnalyticsService.logEvent("click_withdraw")
                 RealmService.shared.resetDB()
                 let loginViewController = LoginViewController()
                 if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/UserWithdrawViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/UserWithdrawViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 import Moya
 import Realm
 import SnapKit
-import FirebaseAnalytics
 
 final class UserWithdrawViewController: BaseViewController {
     override var shouldHideTabBar: Bool { true }
@@ -143,6 +142,7 @@ extension UserWithdrawViewController {
         ) { result in
             switch result {
             case .success:
+                AnalyticsService.logEvent("click_withdraw")
                 RealmService.shared.resetDB()
                 let loginViewController = LoginViewController()
                 if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,

--- a/EATSSU/App/Sources/Presentation/Popup/ViewController/PromotionPopupViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Popup/ViewController/PromotionPopupViewController.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-import FirebaseAnalytics
 import SnapKit
 
 /// 홈 화면 진입 시 노출되는 프로모션 팝업
@@ -79,13 +78,14 @@ final class PromotionPopupViewController: BaseViewController {
     /// 잇슈 인스타그램 바로가기 버튼 클릭 -> 나받돼 게시물로 이동
     @objc
     private func didTapInstagramLinkButton() {
-        print("클릭됨")
+        AnalyticsService.logEvent("click_promotion_popup", parameters: ["action": "instagram_link"])
         UIApplication.shared.open(nabatdaePostURL)
     }
     
     /// 팝업의 그 외 영역 클릭 -> 나아돼 탭으로 이동
     @objc
     private func didTapPopupContent() {
+        AnalyticsService.logEvent("click_promotion_popup", parameters: ["action": "content"])
         dismiss(animated: true) { [weak self] in
             self?.tabBarContainer?.setTab(index: 2)
         }
@@ -94,12 +94,14 @@ final class PromotionPopupViewController: BaseViewController {
     /// 다시 보지 않기 -> 평생 안 뜸
     @objc
     private func didTapNeverShowAgainButton() {
+        AnalyticsService.logEvent("click_promotion_popup", parameters: ["action": "never_show_again"])
         HomePromotionPopupDisplayData.hideForever()
         dismiss(animated: true)
     }
     
     @objc
     private func didTapCloseButton() {
+        AnalyticsService.logEvent("click_promotion_popup", parameters: ["action": "close"])
         dismiss(animated: true)
     }
 }

--- a/EATSSU/App/Sources/Presentation/Popup/ViewController/PromotionPopupViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Popup/ViewController/PromotionPopupViewController.swift
@@ -78,14 +78,12 @@ final class PromotionPopupViewController: BaseViewController {
     /// 잇슈 인스타그램 바로가기 버튼 클릭 -> 나받돼 게시물로 이동
     @objc
     private func didTapInstagramLinkButton() {
-        AnalyticsService.logEvent("click_promotion_popup", parameters: ["action": "instagram_link"])
         UIApplication.shared.open(nabatdaePostURL)
     }
     
     /// 팝업의 그 외 영역 클릭 -> 나아돼 탭으로 이동
     @objc
     private func didTapPopupContent() {
-        AnalyticsService.logEvent("click_promotion_popup", parameters: ["action": "content"])
         dismiss(animated: true) { [weak self] in
             self?.tabBarContainer?.setTab(index: 2)
         }
@@ -94,14 +92,12 @@ final class PromotionPopupViewController: BaseViewController {
     /// 다시 보지 않기 -> 평생 안 뜸
     @objc
     private func didTapNeverShowAgainButton() {
-        AnalyticsService.logEvent("click_promotion_popup", parameters: ["action": "never_show_again"])
         HomePromotionPopupDisplayData.hideForever()
         dismiss(animated: true)
     }
     
     @objc
     private func didTapCloseButton() {
-        AnalyticsService.logEvent("click_promotion_popup", parameters: ["action": "close"])
         dismiss(animated: true)
     }
 }

--- a/EATSSU/App/Sources/Presentation/Popup/ViewController/PromotionPopupViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Popup/ViewController/PromotionPopupViewController.swift
@@ -78,12 +78,20 @@ final class PromotionPopupViewController: BaseViewController {
     /// 잇슈 인스타그램 바로가기 버튼 클릭 -> 나받돼 게시물로 이동
     @objc
     private func didTapInstagramLinkButton() {
+        AnalyticsService.logEvent("popup_event", parameters: [
+            "popup_name": "plz_not_me",
+            "popup_action": "go_insta"
+        ])
         UIApplication.shared.open(nabatdaePostURL)
     }
     
     /// 팝업의 그 외 영역 클릭 -> 나아돼 탭으로 이동
     @objc
     private func didTapPopupContent() {
+        AnalyticsService.logEvent("popup_event", parameters: [
+            "popup_name": "plz_not_me",
+            "popup_action": "click_popup_image"
+        ])
         dismiss(animated: true) { [weak self] in
             self?.tabBarContainer?.setTab(index: 2)
         }
@@ -92,12 +100,20 @@ final class PromotionPopupViewController: BaseViewController {
     /// 다시 보지 않기 -> 평생 안 뜸
     @objc
     private func didTapNeverShowAgainButton() {
+        AnalyticsService.logEvent("popup_event", parameters: [
+            "popup_name": "plz_not_me",
+            "popup_action": "not_show_again"
+        ])
         HomePromotionPopupDisplayData.hideForever()
         dismiss(animated: true)
     }
     
     @objc
     private func didTapCloseButton() {
+        AnalyticsService.logEvent("popup_event", parameters: [
+            "popup_name": "plz_not_me",
+            "popup_action": "close"
+        ])
         dismiss(animated: true)
     }
 }

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/ReportViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/ReportViewController.swift
@@ -9,7 +9,6 @@ import UIKit
 
 import Moya
 import SnapKit
-import FirebaseAnalytics
 
 import EATSSUDesign
 

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/ReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/ReviewViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 import SnapKit
-import FirebaseAnalytics
+
 import Moya
 
 import EATSSUDesign
@@ -201,6 +201,8 @@ final class ReviewViewController: BaseViewController {
     
     /// 리뷰 작성 버튼 탭 처리
     @objc private func handleAddReviewButtonTap() {
+        ReviewAnalyticsManager.shared.logWriteReviewV1()
+
         if type == "VARIABLE" {
             let reviewVC = SetRateViewController(mealId: menuID)
             reviewVC.dataBind(
@@ -344,10 +346,7 @@ final class ReviewViewController: BaseViewController {
     private func setFirebaseTask() {
         FirebaseRemoteConfig.shared.fetchRestaurantInfo()
         
-#if DEBUG
-#else
-        Analytics.logEvent("ReviewViewControllerLoad", parameters: nil)
-#endif
+        AnalyticsService.logEvent("ReviewViewControllerLoad")
     }
     
     /// 작성 후의 새로고침 함수

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/ReviewViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/ReviewViewController.swift
@@ -345,8 +345,6 @@ final class ReviewViewController: BaseViewController {
     /// Firebase 작업 설정
     private func setFirebaseTask() {
         FirebaseRemoteConfig.shared.fetchRestaurantInfo()
-        
-        AnalyticsService.logEvent("ReviewViewControllerLoad")
     }
     
     /// 작성 후의 새로고침 함수

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
@@ -424,8 +424,9 @@ extension SetRateViewController {
 
                 await MainActor.run {
                     self.isReviewSubmitted = true
+                    let hasPhoto = self.userPickedImage != nil || self.setRateView.userReviewImageView.image != nil
                     ReviewAnalyticsManager.shared.logCompleteReviewV1(
-                        photoAttached: 0,
+                        photoAttached: hasPhoto ? 1 : 0,
                         rating: self.setRateView.rateView.currentStar,
                         selection: self.validMenuIDList.count
                     )

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
@@ -421,9 +421,14 @@ extension SetRateViewController {
                 )
                 
                 try await postFixReview(reviewId: reviewId, request: request)
-                
+
                 await MainActor.run {
                     self.isReviewSubmitted = true
+                    ReviewAnalyticsManager.shared.logCompleteReviewV1(
+                        photoAttached: 0,
+                        rating: self.setRateView.rateView.currentStar,
+                        selection: self.validMenuIDList.count
+                    )
                     self.showToast(message: TextLiteral.Review.fixReviewSuccess)
                     self.moveToReviewVC()
                 }
@@ -470,6 +475,11 @@ extension SetRateViewController {
 
                 await MainActor.run {
                     self.isReviewSubmitted = true
+                    ReviewAnalyticsManager.shared.logCompleteReviewV1(
+                        photoAttached: imageUrl != nil ? 1 : 0,
+                        rating: self.setRateView.rateView.currentStar,
+                        selection: self.validMenuIDList.count
+                    )
                     self.moveToReviewVC()
                 }
 
@@ -517,6 +527,11 @@ extension SetRateViewController {
 
                 await MainActor.run {
                     self.isReviewSubmitted = true
+                    ReviewAnalyticsManager.shared.logCompleteReviewV1(
+                        photoAttached: imageUrl != nil ? 1 : 0,
+                        rating: self.setRateView.rateView.currentStar,
+                        selection: self.validMenuIDList.count
+                    )
                     self.moveToReviewVC()
                 }
 

--- a/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Review/ViewController/SetRateViewController.swift
@@ -428,7 +428,7 @@ extension SetRateViewController {
                     ReviewAnalyticsManager.shared.logCompleteReviewV1(
                         photoAttached: hasPhoto ? 1 : 0,
                         rating: self.setRateView.rateView.currentStar,
-                        selection: self.validMenuIDList.count
+                        likes: self.likedStates.filter { $0 }.count
                     )
                     self.showToast(message: TextLiteral.Review.fixReviewSuccess)
                     self.moveToReviewVC()
@@ -479,7 +479,7 @@ extension SetRateViewController {
                     ReviewAnalyticsManager.shared.logCompleteReviewV1(
                         photoAttached: imageUrl != nil ? 1 : 0,
                         rating: self.setRateView.rateView.currentStar,
-                        selection: self.validMenuIDList.count
+                        likes: self.likedStates.filter { $0 }.count
                     )
                     self.moveToReviewVC()
                 }
@@ -531,7 +531,7 @@ extension SetRateViewController {
                     ReviewAnalyticsManager.shared.logCompleteReviewV1(
                         photoAttached: imageUrl != nil ? 1 : 0,
                         rating: self.setRateView.rateView.currentStar,
-                        selection: self.validMenuIDList.count
+                        likes: self.likedStates.filter { $0 }.count
                     )
                     self.moveToReviewVC()
                 }

--- a/EATSSU/App/Sources/Presentation/Splash/NoticeSplashViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Splash/NoticeSplashViewController.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 import SnapKit
-import FirebaseAnalytics
 
 import EATSSUDesign
 

--- a/EATSSU/App/Sources/Presentation/Splash/SplashViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Splash/SplashViewController.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 import SnapKit
-import FirebaseAnalytics
 
 import EATSSUDesign
 

--- a/EATSSU/App/Sources/Presentation/TabBar/CustomTabBarContainerController.swift
+++ b/EATSSU/App/Sources/Presentation/TabBar/CustomTabBarContainerController.swift
@@ -255,6 +255,11 @@ extension CustomTabBarContainerController: UITabBarControllerDelegate {
         
         // 커피 탭: 전체화면 모달로 웹뷰 표시
         if selectedTab == .coffee {
+            let userInfo = UserInfoManager.shared.getCurrentUserInfo()
+            var params: [String: Any] = [:]
+            if let collegeId = userInfo?.collegeId { params["college"] = collegeId }
+            if let majorId = userInfo?.departmentId { params["major"] = majorId }
+            AnalyticsService.logEvent("click_plz_not_me", parameters: params)
             presentCoffeeWebView()
             return false
         }

--- a/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
@@ -97,7 +97,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         let config = PostHogConfig(apiKey: apiKey, host: "https://us.i.posthog.com")
         config.captureApplicationLifecycleEvents = true
-        config.captureScreenViews = false
+        config.captureScreenViews = true
 
         PostHogSDK.shared.setup(config)
         #endif

--- a/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
@@ -50,6 +50,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             } else {
                 LaunchSourceManager.shared.setSource(.icon)
             }
+
+            // PostHog Deep Link 이벤트
+            AnalyticsService.logEvent("Deep Link Opened", parameters: ["url": url.absoluteString])
         }
     }
 

--- a/EATSSU/Widget/Sources/Data/Timeline/ESTimelineProvider.swift
+++ b/EATSSU/Widget/Sources/Data/Timeline/ESTimelineProvider.swift
@@ -105,7 +105,7 @@ struct ESTimelineProvider: AppIntentTimelineProvider {
                 WidgetAnalyticsManager.shared.recordWidgetChanged(before: oldRestaurant, after: newRestaurant)
             }
         } else {
-            WidgetAnalyticsManager.shared.recordWidgetAdded()
+            WidgetAnalyticsManager.shared.recordWidgetAdded(restaurant: newRestaurant)
         }
         userDefaults?.set(newRestaurant, forKey: lastRestaurantKey)
     }


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #405 

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

PostHog 도입 이후 정의만 되어 있고 실제로 호출되지 않던 이벤트들을 연결하고, 추적되지 않던 주요 사용자 인터랙션에 대한 신규 이벤트를 추가했습니다.

**누락된 이벤트 호출 연결**
- `click_partner_restaurant`: 제휴점 마커 클릭 시 호출 추가 (`partner_restaurant_id`, `college`, `major` 파라미터 포함)
  - `partnershipInfos`가 비어있어도 이벤트가 전송되도록 nil 분기 제거
- `write_review_v2`: 리뷰 작성 버튼 탭 시 호출 추가
- `complete_review_v2`: 리뷰 제출 완료 시 호출 추가 (`photo_attached`, `rating`, `selection` 파라미터 포함)
  - 리뷰 수정 시에도 실제 사진 첨부 상태를 정확히 반영하도록 수정
- `ReviewViewControllerLoad`: 기존 직접 Firebase 호출을 `AnalyticsService.logEvent`로 변경하여 PostHog에도 전송되도록 수정

**신규 이벤트 추적 추가**
- `click_login`: 카카오/애플/게스트 로그인 버튼 클릭 (`method` 파라미터)
- `complete_login`: 카카오/애플 로그인 성공 (`method` 파라미터)
- `click_mypage_menu`: 마이페이지 메뉴 항목 클릭 - 알림설정, 내 정보, 내 리뷰, 문의하기, 이용약관, 개인정보, 만든사람들, 회원탈퇴 (`menu` 파라미터)
- `click_logout`: 로그아웃 확인
- `click_withdraw`: 회원탈퇴 완료
- `click_map_all`: 지도 "전체" 버튼 클릭
- `click_creator_link`: 크리에이터 페이지 링크 클릭 - 인스타그램, 랜딩페이지 (`type` 파라미터)

**이벤트 이름 통일 및 수정**
- `select_day` → `click_day`로 변경 (안드로이드와 이벤트 이름 통일)
- 리뷰 이벤트 이름 `v1` → `v2`로 변경 (현재 리뷰 UI에 맞게)
- `click_promotion_popup` 이벤트 제거 (임시 이벤트)

**PostHog 설정 개선**
- `captureScreenViews = true`로 변경하여 `screen_view` 자동 캡처 활성화
- SceneDelegate에서 `Deep Link Opened` 이벤트 수동 전송 추가

**불필요한 import 정리**
- Presentation 레이어의 11개 ViewController에서 `import FirebaseAnalytics` 제거
- 모든 이벤트가 `AnalyticsService`를 경유하므로 직접 import 불필요

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 모든 이벤트는 `AnalyticsService.logEvent`를 통해 Firebase + PostHog 양쪽에 동시 전송됩니다.
- PostHog 유저 식별(`identify`)은 이메일 저장 구조 확립 후 별도 PR에서 적용 예정입니다.
- PostHog Activity에서 `click_partner_restaurant`, `click_map`, `click_day` 등 실시간 이벤트 수신 확인 완료했습니다.