### PR TITLE
[#407] 공휴일 API를 사용하여 스낵코너 메뉴 처리

### DIFF
--- a/EATSSU/App/Sources/Data/Network/DTO/Home/PublicHolidayResponseDTO.swift
+++ b/EATSSU/App/Sources/Data/Network/DTO/Home/PublicHolidayResponseDTO.swift
@@ -1,0 +1,59 @@
+//
+//  PublicHolidayResponseDTO.swift
+//  EATSSU
+//
+//  Created by jeongminji on 3/25/26.
+//
+
+import Foundation
+
+struct PublicHolidayResponseDTO: Decodable {
+    let response: PublicHolidayEnvelopeDTO
+}
+
+struct PublicHolidayEnvelopeDTO: Decodable {
+    let header: PublicHolidayHeaderDTO
+    let body: PublicHolidayBodyDTO
+}
+
+struct PublicHolidayHeaderDTO: Decodable {
+    let resultCode: String
+}
+
+struct PublicHolidayBodyDTO: Decodable {
+    let items: PublicHolidayItemsDTO?
+}
+
+struct PublicHolidayItemsDTO: Decodable {
+    let item: PublicHolidayItemContainerDTO
+}
+
+struct PublicHolidayItemDTO: Decodable {
+    let dateName: String?
+    let isHoliday: String?
+    let locdate: Int
+}
+
+enum PublicHolidayItemContainerDTO: Decodable {
+    case one(PublicHolidayItemDTO)
+    case many([PublicHolidayItemDTO])
+    
+    var values: [PublicHolidayItemDTO] {
+        switch self {
+        case let .one(item):
+            return [item]
+        case let .many(items):
+            return items
+        }
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        
+        if let items = try? container.decode([PublicHolidayItemDTO].self) {
+            self = .many(items)
+        } else {
+            self = .one(try container.decode(PublicHolidayItemDTO.self))
+        }
+    }
+}

--- a/EATSSU/App/Sources/Data/Network/Router/PublicHolidayRouter.swift
+++ b/EATSSU/App/Sources/Data/Network/Router/PublicHolidayRouter.swift
@@ -1,0 +1,58 @@
+//
+//  PublicHolidayRouter.swift
+//  EATSSU
+//
+//  Created by jeongminji on 3/25/26.
+//
+
+import Foundation
+import Moya
+
+enum PublicHolidayRouter {
+    case getPublicHolidays(serviceKey: String, year: Int, month: Int)
+}
+
+extension PublicHolidayRouter: TargetType {
+    var baseURL: URL {
+        URL(string: "https://apis.data.go.kr")!
+    }
+    
+    var path: String {
+        switch self {
+        case .getPublicHolidays:
+            "/B090041/openapi/service/SpcdeInfoService/getRestDeInfo"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getPublicHolidays:
+                .get
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case let .getPublicHolidays(serviceKey, year, month):
+            return .requestParameters(
+                parameters: [
+                    "ServiceKey": serviceKey,
+                    "solYear": String(year),
+                    "solMonth": String(format: "%02d", month),
+                    "numOfRows": 50,
+                    "pageNo": 1,
+                    "_type": "json"
+                ],
+                encoding: URLEncoding.queryString
+            )
+        }
+    }
+    
+    var headers: [String: String]? {
+        ["Content-type": "application/json"]
+    }
+    
+    var sampleData: Data {
+        Data()
+    }
+}

--- a/EATSSU/App/Sources/Presentation/Home/Enum/HolidayAPIConstant.swift
+++ b/EATSSU/App/Sources/Presentation/Home/Enum/HolidayAPIConstant.swift
@@ -1,0 +1,13 @@
+//
+//  HolidayAPIConstant.swift
+//  EATSSU
+//
+//  Created by jeongminji on 3/25/26.
+//
+
+enum HolidayAPIConstant {
+    static let cacheKeyPrefix = "publicHolidayCache_"
+    static let infoPlistKey = "HOLIDAY_API_KEY"
+    static let successResultCode = "00"
+    static let holidayFlag = "Y"
+}

--- a/EATSSU/App/Sources/Presentation/Home/ViewController/HomeRestaurantViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Home/ViewController/HomeRestaurantViewController.swift
@@ -211,12 +211,17 @@ final class HomeRestaurantViewController: BaseViewController {
         return holidayDates.contains(targetDate)
     }
     
-    // 날짜를 yyyyMMdd 포맷 문자열로 변환
+    // 날짜를 yyyyMMdd 문자열로 변환
     private func changeDateFormat(date: Date) -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyyMMdd"
-        return dateFormatter.string(from: date)
+        return Self.yyyyMMddDateFormatter.string(from: date)
     }
+    
+    ///"yyyyMMdd 포맷팅하기 위한 DateFormatter 인스턴스
+    private static let yyyyMMddDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd"
+        return formatter
+    }()
     
     /// 스낵코너 메뉴를 비우고 UI를 갱신
     private func hideSnackCorner() {

--- a/EATSSU/App/Sources/Presentation/Home/ViewController/HomeRestaurantViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Home/ViewController/HomeRestaurantViewController.swift
@@ -482,13 +482,15 @@ extension HomeRestaurantViewController {
         let year = Calendar.current.component(.year, from: date)
         let month = Calendar.current.component(.month, from: date)
         
-        let cacheKey = "publicHolidayCache_\(year)_\(String(format: "%02d", month))"
+        let cacheKey = "\(HolidayAPIConstant.cacheKeyPrefix)\(year)_\(String(format: "%02d", month))"
         
         if let cached = UserDefaults.standard.array(forKey: cacheKey) as? [String] {
             return cached
         }
         
-        let serviceKey = Bundle.main.object(forInfoDictionaryKey: "HOLIDAY_API_KEY") as? String ?? ""
+        let serviceKey = Bundle.main.object(
+            forInfoDictionaryKey: HolidayAPIConstant.infoPlistKey
+        ) as? String ?? ""
         let trimmedServiceKey = serviceKey.trimmingCharacters(in: .whitespacesAndNewlines)
         
         guard !trimmedServiceKey.isEmpty else {
@@ -512,7 +514,7 @@ extension HomeRestaurantViewController {
             
             let decoded = try response.map(PublicHolidayResponseDTO.self)
             
-            guard decoded.response.header.resultCode == "00" else {
+            guard decoded.response.header.resultCode == HolidayAPIConstant.successResultCode else {
                 return []
             }
             
@@ -520,7 +522,7 @@ extension HomeRestaurantViewController {
             let holidayDates = Array(
                 Set(
                     items
-                        .filter { $0.isHoliday == "Y" }
+                        .filter { $0.isHoliday == HolidayAPIConstant.holidayFlag }
                         .map { String($0.locdate) }
                 )
             ).sorted()

--- a/EATSSU/App/Sources/Presentation/Home/ViewController/HomeRestaurantViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Home/ViewController/HomeRestaurantViewController.swift
@@ -173,33 +173,62 @@ final class HomeRestaurantViewController: BaseViewController {
                 }
             }
         }
-
+        
         // Task를 AnyCancellable로 변환해서 저장 (취소 가능하도록)
         cancellables.insert(AnyCancellable { task.cancel() })
         
         let weekday = Weekday.from(date: date)
         isWeekend = weekday.isWeekend
+        
+        guard time == MealTime.lunch.rawValue else {
+            hideSnackCorner()
+            return
+        }
 
-        if time == MealTime.lunch.rawValue {
-            // 학기 중 평일 점심에만 스낵 고정 메뉴 요청
-            if !FirebaseRemoteConfig.shared.isVacationPeriod, !weekday.isWeekend {
-                isSelectable = true
-                let fixTask = _Concurrency.Task {
-                    await self.fetchFixedMenuData(restaurant: RestaurantIdentifier.snackCorner.rawValue)
-                }
-                cancellables.insert(AnyCancellable { fixTask.cancel() })
+        let snackTask = _Concurrency.Task { [weak self] in
+            guard let self else { return }
+
+            let isHoliday = await self.isHoliday(date: date)
+
+            if !FirebaseRemoteConfig.shared.isVacationPeriod,
+               !weekday.isWeekend,
+               !isHoliday {
+                self.isSelectable = true
+                await self.fetchFixedMenuData(restaurant: RestaurantIdentifier.snackCorner.rawValue)
             } else {
-                // 방학/주말 더미
-                fixMenuTableViewData[RestaurantIdentifier.snackCorner.rawValue] = []
+                self.hideSnackCorner()
             }
         }
+        cancellables.insert(AnyCancellable { snackTask.cancel() })
     }
-
+    
+    // MARK: - Private Functions
+    
+    /// 특정 날짜가 공휴일인지 판단
+    private func isHoliday(date: Date) async -> Bool {
+        let targetDate = changeDateFormat(date: date)
+        let holidayDates = await fetchHolidays(date: date)
+        return holidayDates.contains(targetDate)
+    }
+    
     // 날짜를 yyyyMMdd 포맷 문자열로 변환
-    func changeDateFormat(date: Date) -> String {
+    private func changeDateFormat(date: Date) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyyMMdd"
         return dateFormatter.string(from: date)
+    }
+    
+    /// 스낵코너 메뉴를 비우고 UI를 갱신
+    private func hideSnackCorner() {
+        isSelectable = false
+        fixMenuTableViewData[RestaurantIdentifier.snackCorner.rawValue] = []
+        
+        if let sectionIndex = getSectionIndex(for: RestaurantIdentifier.snackCorner.rawValue) {
+            restaurantView.restaurantTableView.reloadSections(
+                IndexSet(integer: sectionIndex),
+                with: .none
+            )
+        }
     }
 }
 
@@ -440,6 +469,62 @@ extension HomeRestaurantViewController {
             if let sectionIndex = self.getSectionIndex(for: restaurant) {
                 self.restaurantView.restaurantTableView.reloadSections(IndexSet(integer: sectionIndex), with: animation)
             }
+        }
+    }
+    
+    // 공휴일 조회 API 호출
+    func fetchHolidays(date: Date) async -> [String] {
+        let year = Calendar.current.component(.year, from: date)
+        let month = Calendar.current.component(.month, from: date)
+        
+        let cacheKey = "publicHolidayCache_\(year)_\(String(format: "%02d", month))"
+        
+        if let cached = UserDefaults.standard.array(forKey: cacheKey) as? [String] {
+            return cached
+        }
+        
+        let serviceKey = Bundle.main.object(forInfoDictionaryKey: "HOLIDAY_API_KEY") as? String ?? ""
+        let trimmedServiceKey = serviceKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        guard !trimmedServiceKey.isEmpty else {
+            return []
+        }
+        
+        let provider = MoyaProvider<PublicHolidayRouter>()
+        
+        do {
+            let response = try await withCheckedThrowingContinuation { continuation in
+                provider.request(
+                    .getPublicHolidays(
+                        serviceKey: trimmedServiceKey,
+                        year: year,
+                        month: month
+                    )
+                ) { result in
+                    continuation.resume(with: result)
+                }
+            }
+            
+            let decoded = try response.map(PublicHolidayResponseDTO.self)
+            
+            guard decoded.response.header.resultCode == "00" else {
+                return []
+            }
+            
+            let items = decoded.response.body.items?.item.values ?? []
+            let holidayDates = Array(
+                Set(
+                    items
+                        .filter { $0.isHoliday == "Y" }
+                        .map { String($0.locdate) }
+                )
+            ).sorted()
+            
+            UserDefaults.standard.set(holidayDates, forKey: cacheKey)
+            return holidayDates
+        } catch {
+            print("공휴일 조회 실패: \(error.localizedDescription)")
+            return []
         }
     }
 }


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
Resolved #407

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 공휴일 API 연동
- `PublicHolidayRouter` 추가하여 외부 Open API 호출
- Moya 기반으로 GET 요청 구성
- Info.plist의 `HOLIDAY_API_KEY`를 사용하여 API 키 주입
    → Debug.xcconfig, Release.xcconfig에 `HOLIDAY_API_KEY` 추가 필요🌟

2. 공휴일 판별 로직 추가
- `isHoliday(date:) async -> Bool` 함수 추가
- `fetchHolidays(date:)`를 통해 해당 월 공휴일 목록 조회 후 날짜 비교
- 스낵코너 노출 조건 변경
    - 기존: 점심 + 방학 아님 + 주말 아님
    - 변경: 점심 + 방학 아님 + 주말 아님 + 공휴일 아님

4. fetchData 구조 유지 + async 적용
- 기존 `fetchData`를 async로 변경하지 않고 내부에서 `_Concurrency.Task` 사용
- 기존 호출부 영향 없이 공휴일 체크만 비동기 처리

5. 공휴일 캐싱 추가 ⇒ Android와 동일한 정책(월 캐싱) 적용
- 동일 월에 대해 API 중복 호출 방지
- `UserDefaults`를 사용하여 캐싱
```swift
publicHolidayCache_{year}_{month}
```

6. 예외 처리 (Fallback) → 공휴일 조회 실패 시 기존 로직 유지 (스낵코너 노출)
- API 호출 실패 / 디코딩 실패 / 키 없음 → 빈 배열 반환
- 결과적으로 `isHoliday == false` 처리
- 공휴일 조회 실패 시 기존 로직 유지 (스낵코너 노출)


https://github.com/user-attachments/assets/dac12705-5a9e-4e88-be97-a53c6207d0c2


### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
공휴일 API Key를 기존 카카오 로그인 키처럼 Info.plist에서 직접 가져오는 방식으로 구현했는데 이 방향이 괜찮을지 의견 부탁드립니다!

Debug.xcconfig, Release.xcconfig에 `HOLIDAY_API_KEY` 추가 필요합니다!🌟
-> 노션 iOS 페이지 Secrets 파일 업데이트 해두었습니다!

