### PR TITLE
[#411] 학과 정보 서버 확인 전 제휴 API 호출되는 Race Condition 수정

### DIFF
--- a/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController.swift
@@ -86,7 +86,6 @@ final class MainMapViewController: BaseViewController {
                 self.fetchPartnerships()
             }
 
-            self.updateMyOnlyButtonTitle()
         }
     }
 

--- a/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Map/ViewController/MainMapViewController.swift
@@ -57,13 +57,11 @@ final class MainMapViewController: BaseViewController {
         super.viewDidLoad()
 
         locationManager.delegate = self
-        
+
         configureNavigationBar()
         setInitialCameraPosition(animated: false)
         setupLocationButtonObserver()
         setupMarkerTapHandler()
-        
-        fetchDepartmentAndUpdateButton()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -74,22 +72,22 @@ final class MainMapViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        // 학과 정보 다시 로드
-        loadDepartmentFromRealm()
-        
-        // 학과가 있으면 학과별 제휴로 시작, 없으면 전체로 시작
-        if let departmentName = currentDepartmentName, !departmentName.isEmpty {
-            currentMapMode = .myOnly
-            root.selectWhole(false)
-            fetchMyPartnerships()
-        } else {
-            currentMapMode = .all
-            root.selectWhole(true)
-            fetchPartnerships()
+        // 서버에서 학과 정보를 확인한 후, 결과에 따라 적절한 API 호출
+        fetchDepartmentAndUpdateButton { [weak self] in
+            guard let self = self else { return }
+
+            if let departmentName = self.currentDepartmentName, !departmentName.isEmpty {
+                self.currentMapMode = .myOnly
+                self.root.selectWhole(false)
+                self.fetchMyPartnerships()
+            } else {
+                self.currentMapMode = .all
+                self.root.selectWhole(true)
+                self.fetchPartnerships()
+            }
+
+            self.updateMyOnlyButtonTitle()
         }
-        
-        // 버튼 텍스트 업데이트
-        updateMyOnlyButtonTitle()
     }
 
     // MARK: - Configuration


### PR DESCRIPTION
### 🔗 연결된 이슈
Resolved #411

✨ 주요 작업사항
> 이번 PR의 핵심 변경사항을 알려주세요!

- `viewWillAppear`에서 Realm(로컬 DB) 데이터 기반으로 제휴 API를 즉시 호출하던 로직을, 서버에서 학과 정보를 확인한 후 호출하도록 변경
- `viewDidLoad`에서 중복 호출되던 `fetchDepartmentAndUpdateButton()` 제거

**기존 문제**
- `viewDidLoad` → `fetchDepartmentAndUpdateButton()` (비동기, 응답 대기중)
- `viewWillAppear` → Realm에서 이전 세션의 학과 데이터를 읽고 바로 `fetchMyPartnerships()` 호출
- 서버에는 학과 정보가 없는 상태에서 API가 호출되어 `MISSING_USER_DEPARTMENT` 에러 발생

**수정 후**
- `viewWillAppear`에서 서버 학과 확인이 완료된 후에만 제휴 API를 호출하도록 순서 보장

### 🔍 리뷰어에게 (선택)
> 코드 리뷰 시 특별히 확인했으면 하는 부분이나, 의견을 묻고 싶은 내용을 적어주세요!

- x