### PR TITLE
[#420] 둘러보기 버튼 말풍선에 가려지지 않게 수정 

### DIFF
--- a/EATSSU/App/Sources/Presentation/Auth/View/LoginView.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/View/LoginView.swift
@@ -69,12 +69,12 @@ final class LoginView: BaseUIView {
 
         appleLoginButton.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(151)
+            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(176)
         }
 
         kakaoLoginButton.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(90)
+            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(115)
         }
 
         lookingWithNoSignInButton.snp.makeConstraints {

--- a/EATSSU/Project.swift
+++ b/EATSSU/Project.swift
@@ -124,7 +124,6 @@ let project = Project(
                 .external(name: "Moya"),
                 .external(name: "FSCalendar"),
                 .external(name: "Kingfisher"),
-                .external(name: "GoogleAppMeasurement"),
                 .external(name: "Realm"),
                 .external(name: "RealmSwift"),
                 .external(name: "FirebaseCrashlytics"),
@@ -180,7 +179,6 @@ let project = Project(
                 .external(name: "Moya"),
                 .external(name: "FSCalendar"),
                 .external(name: "Kingfisher"),
-                .external(name: "GoogleAppMeasurement"),
                 .external(name: "Realm"),
                 .external(name: "RealmSwift"),
                 .external(name: "FirebaseCrashlytics"),
@@ -230,8 +228,6 @@ let project = Project(
             dependencies: [
                 .external(name: "Moya"),
                 .external(name: "CombineMoya"),
-                .external(name: "FirebaseAnalytics"),
-                .external(name: "GoogleAppMeasurement"),
 
                 // EATSSU 내장 라이브러리
                 .project(target: "EATSSUDesign", path: .relativeToRoot("../EATSSUDesign"), condition: .none),
@@ -270,8 +266,6 @@ let project = Project(
             dependencies: [
                 .external(name: "Moya"),
                 .external(name: "CombineMoya"),
-                .external(name: "FirebaseAnalytics"),
-                .external(name: "GoogleAppMeasurement"),
 
                 // EATSSU 내장 라이브러리
                 .project(target: "EATSSUDesign", path: .relativeToRoot("../EATSSUDesign"), condition: .none),

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -27,6 +27,18 @@ import PackageDescription
             "Firebase": .framework,
             "GoogleAppMeasurement": .framework,
 
+            // GoogleUtilities / nanopb 등의 정적 product를 동적 프레임워크로 변환
+            // (FirebaseAnalytics가 transitive로 가져오면서 GoogleAppMeasurementTarget과 중복 링크되는 경고 방지)
+            "GoogleUtilities-AppDelegateSwizzler": .framework,
+            "GoogleUtilities-Environment": .framework,
+            "GoogleUtilities-Logger": .framework,
+            "GoogleUtilities-MethodSwizzler": .framework,
+            "GoogleUtilities-NSData": .framework,
+            "GoogleUtilities-Network": .framework,
+            "GoogleUtilities-Reachability": .framework,
+            "nanopb": .framework,
+            "third-party-IsAppEncrypted": .framework,
+
             // realm-swift
             "Realm": .framework,
             "RealmSwift": .framework,


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #420

  ### 💡작업 내용
  - 애플/카카오 로그인 버튼을 25pt씩 위로 올렸습니다. (둘러보기 버튼 위치는 그대로)
    - Apple: bottom inset 151 → 176
    - 카카오: bottom inset 90 → 115
  - `tuist generate` 시 발생하던 정적 라이브러리 중복 링크 경고를 제거했습니다.
    - 위젯 타겟에서 불필요한 `FirebaseAnalytics` / `GoogleAppMeasurement` 의존성 제거
    - 앱 타겟에서 중복 명시된 `GoogleAppMeasurement` 제거 (`FirebaseAnalytics`가 transitive로 가져옴)
    - `GoogleUtilities-*`, `nanopb`, `third-party-IsAppEncrypted`를 동적 framework로 변환

<img width="250" alt="Simulator Screenshot - iPhone Air - 2026-05-09 at 17 40 42" src="https://github.com/user-attachments/assets/a936c0f5-3b52-48e5-ad25-199158261444" />


### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- 둘러보기 버튼 말고 로그인 버튼을 위로 올렸습니다. 
