### PR TITLE
[#424] 만든 사람들 메뉴를 노션 페이지 웹뷰로 변경

### DIFF
--- a/EATSSU/App/Sources/Presentation/MyPage/View/CreatorsView.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/View/CreatorsView.swift
@@ -12,6 +12,7 @@ import SnapKit
 import EATSSUDesign
 
 /// "만든 사람들"을 담고 있는 View 입니다.
+/// - Note: 현재는 노션 페이지로 대체되어 사용하지 않습니다. 추후 복구 가능성을 위해 남겨둡니다.
 class CreatorsView: BaseUIView {
     // MARK: - UI Components
     

--- a/EATSSU/App/Sources/Presentation/MyPage/View/ProvisionView.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/View/ProvisionView.swift
@@ -28,6 +28,13 @@ final class ProvisionView: BaseUIView {
         connectWebLink(agreementType: agreementType)
     }
 
+    init(url: URL) {
+        webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        super.init(frame: .zero)
+
+        webView.load(URLRequest(url: url))
+    }
+
     // MARK: - Functions
 
     override func configureUI() {

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/CreatorViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/CreatorViewController.swift
@@ -13,6 +13,8 @@ import SnapKit
 
 import EATSSUDesign
 
+/// "만든 사람들" 화면 ViewController.
+/// - Note: 현재는 노션 페이지로 대체되어 사용하지 않습니다. 추후 복구 가능성을 위해 남겨둡니다.
 class CreatorViewController: BaseViewController {
     override var shouldHideTabBar: Bool { true }
     // MARK: - Properties

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -234,11 +234,14 @@ extension MyPageViewController: UITableViewDelegate {
             provisionViewController.navigationTitle = TextLiteral.MyPage.privacyTermsOfUse
             navigationController?.pushViewController(provisionViewController, animated: true)
 
-        // "만든사람들" 스크린으로 이동
+        // "만든사람들" 노션 페이지로 이동 (앱 내 웹뷰)
         case MyPageLabels.Creator.rawValue:
             AnalyticsService.logEvent("click_mypage_menu", parameters: ["menu": "creator"])
-            let creatorViewController = CreatorViewController()
-            navigationController?.pushViewController(creatorViewController, animated: true)
+            if let creatorsURL = URL(string: "https://eat-ssu.notion.site/1d2eeef75a16814db1e5c5abaf40cf6a") {
+                let creatorsWebVC = ProvisionViewController(url: creatorsURL)
+                creatorsWebVC.navigationTitle = TextLiteral.MyPage.creators
+                navigationController?.pushViewController(creatorsWebVC, animated: true)
+            }
 
         // "로그아웃" 팝업알림 표시
         case MyPageLabels.Logout.rawValue:

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -17,6 +17,10 @@ import SnapKit
 final class MyPageViewController: BaseViewController {
     // MARK: - Properties
 
+    private enum URLConstants {
+        static let creatorsNotion = "https://eat-ssu.notion.site/1d2eeef75a16814db1e5c5abaf40cf6a"
+    }
+
     private var nickName = ""
     private var switchState = false
     private let myPageTableLabelList = MyPageLocalData.myPageTableLabelList
@@ -237,7 +241,7 @@ extension MyPageViewController: UITableViewDelegate {
         // "만든사람들" 노션 페이지로 이동 (앱 내 웹뷰)
         case MyPageLabels.Creator.rawValue:
             AnalyticsService.logEvent("click_mypage_menu", parameters: ["menu": "creator"])
-            if let creatorsURL = URL(string: "https://eat-ssu.notion.site/1d2eeef75a16814db1e5c5abaf40cf6a") {
+            if let creatorsURL = URL(string: URLConstants.creatorsNotion) {
                 let creatorsWebVC = ProvisionViewController(url: creatorsURL)
                 creatorsWebVC.navigationTitle = TextLiteral.MyPage.creators
                 navigationController?.pushViewController(creatorsWebVC, animated: true)

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/ProvisionViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/ProvisionViewController.swift
@@ -32,6 +32,12 @@ final class ProvisionViewController: BaseViewController {
         super.init(nibName: nil, bundle: nil)
     }
 
+    init(url: URL) {
+        provisionView = ProvisionView(url: url)
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 


### PR DESCRIPTION
### #️⃣ 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

Resolved #424

### 💡작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

  - 마이 탭 "만든 사람들" → 노션 페이지 in-app 웹뷰로 교체
  - `ProvisionView`/`ProvisionViewController`에 `init(url:)` 추가
  - 기존 `CreatorsView`/`CreatorViewController`는 보존, 미사용 안내 주석 추가

<img width="295" height="640" alt="Simulator Screen Recording - iPhone Air - 2026-05-23 at 16 58 27" src="https://github.com/user-attachments/assets/bf06599f-6716-4e0c-988e-e603992d8ec3" />


### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 <br/> <br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- x 