### PR TITLE
[Feat] 파이어베이스/PostHog 이벤트 추가 및 유저 식별(identify) 구현

### DIFF
--- a/EATSSU/App/Sources/Data/Firebase/AnalyticsIdentityManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/AnalyticsIdentityManager.swift
@@ -1,0 +1,90 @@
+//
+//  AnalyticsIdentityManager.swift
+//  EATSSU
+//
+//  Created by 황상환 on 7/4/26.
+//
+
+import FirebaseAnalytics
+import PostHog
+
+/// PostHog / Firebase 유저 식별(identify) 담당.
+///
+/// iOS는 로그인 시 이메일을 안정적으로 확보할 수 없어(애플 로그인은 최초 1회만 제공),
+/// 이메일 대신 **기기 단위 고유 UUID**를 식별자로 사용한다.
+/// 이 UUID는 Keychain에 저장되어 로그아웃/재설치 후에도 유지된다.
+///
+/// - 주의: 기기 단위 식별이므로 동일인의 크로스 디바이스/안드로이드 통합은 불가하다.
+///   (그 수준이 필요하면 백엔드가 내려주는 고유 memberId로 교체해야 한다.)
+enum AnalyticsIdentityManager {
+
+    private enum Key {
+        static let deviceUserID = "analytics_device_user_id"
+    }
+
+    private enum Property {
+        static let provider = "provider"
+        static let collegeId = "college_id"
+        static let collegeName = "college_name"
+        static let departmentId = "department_id"
+        static let departmentName = "department_name"
+    }
+
+    /// 기기 단위 고유 식별자. 없으면 생성하여 Keychain에 저장한다.
+    private static var deviceUserID: String {
+        if let saved = KeychainHelper.read(forKey: Key.deviceUserID) {
+            return saved
+        }
+        let newID = UUID().uuidString
+        KeychainHelper.save(newID, forKey: Key.deviceUserID)
+        return newID
+    }
+
+    /// 로그인 성공 또는 유저 정보 갱신 시 호출.
+    /// 현재 저장된 `UserInfo`를 읽어 유저 속성으로 붙인다. (있는 값만)
+    static func identify() {
+        let id = deviceUserID
+        var properties: [String: Any] = [:]
+
+        if let userInfo = UserInfoManager.shared.getCurrentUserInfo() {
+            // provider는 기존 login 이벤트(method)와 동일하게 소문자로 맞춘다.
+            if let provider = userInfo.accountType?.rawValue.lowercased() {
+                properties[Property.provider] = provider
+            }
+            if let collegeId = userInfo.collegeId { properties[Property.collegeId] = collegeId }
+            if let collegeName = userInfo.collegeName { properties[Property.collegeName] = collegeName }
+            if let departmentId = userInfo.departmentId { properties[Property.departmentId] = departmentId }
+            if let departmentName = userInfo.departmentName { properties[Property.departmentName] = departmentName }
+        }
+
+        #if DEBUG
+        print("👤 [Identify] id: \(id)")
+        print("👤 [Identify] properties: \(properties)")
+        #endif
+
+        #if !DEBUG
+        PostHogSDK.shared.identify(id, userProperties: properties.isEmpty ? nil : properties)
+        #endif
+
+        Analytics.setUserID(id)
+        properties.forEach { key, value in
+            Analytics.setUserProperty("\(value)", forName: key)
+        }
+    }
+
+    /// 로그아웃 시 호출.
+    static func reset() {
+        #if !DEBUG
+        PostHogSDK.shared.reset()
+        #endif
+        Analytics.setUserID(nil)
+        // 이전 유저의 속성이 다음 유저에게 남지 않도록 함께 비운다.
+        [Property.provider,
+         Property.collegeId,
+         Property.collegeName,
+         Property.departmentId,
+         Property.departmentName].forEach {
+            Analytics.setUserProperty(nil, forName: $0)
+        }
+    }
+}

--- a/EATSSU/App/Sources/Data/Firebase/AnalyticsIdentityManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/AnalyticsIdentityManager.swift
@@ -30,13 +30,21 @@ enum AnalyticsIdentityManager {
         static let departmentName = "department_name"
     }
 
+    /// Keychain 조회(IPC)를 매번 하지 않도록 프로세스 생명주기 동안 캐싱한다.
+    private static var cachedDeviceUserID: String?
+
     /// 기기 단위 고유 식별자. 없으면 생성하여 Keychain에 저장한다.
     private static var deviceUserID: String {
+        if let cached = cachedDeviceUserID {
+            return cached
+        }
         if let saved = KeychainHelper.read(forKey: Key.deviceUserID) {
+            cachedDeviceUserID = saved
             return saved
         }
         let newID = UUID().uuidString
         KeychainHelper.save(newID, forKey: Key.deviceUserID)
+        cachedDeviceUserID = newID
         return newID
     }
 

--- a/EATSSU/App/Sources/Data/Firebase/AnalyticsService.swift
+++ b/EATSSU/App/Sources/Data/Firebase/AnalyticsService.swift
@@ -24,7 +24,10 @@ enum AnalyticsService {
             AnalyticsParameterScreenClass: screenClass
         ])
         #if !DEBUG
-        PostHogSDK.shared.screen(name, properties: [
+        // Firebase와 이벤트명/파라미터 키를 맞추기 위해 PostHog 네이티브 .screen($screen) 대신
+        // screen_view 커스텀 이벤트로 발사
+        PostHogSDK.shared.capture("screen_view", properties: [
+            AnalyticsParameterScreenName: name,
             AnalyticsParameterScreenClass: screenClass
         ])
         #endif

--- a/EATSSU/App/Sources/Data/Firebase/LaunchSourceManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/LaunchSourceManager.swift
@@ -73,7 +73,10 @@ final class LaunchSourceManager {
 
         // 아직 로깅하지 않았으면 로깅 수행
         if !hasLogged {
-            AnalyticsService.logEvent("app_launch", parameters: ["launch_path": source.rawValue])
+            AnalyticsService.logEvent("app_launch", parameters: [
+                "launch_path": source.rawValue,
+                "app_locale": AppLanguageManager.shared.currentLanguage.rawValue
+            ])
             hasLogged = true
 
             print("App launch logged: \(source.rawValue) (New session: \(isNewSession))")

--- a/EATSSU/App/Sources/Data/Firebase/MyPageAnalyticsManager.swift
+++ b/EATSSU/App/Sources/Data/Firebase/MyPageAnalyticsManager.swift
@@ -36,6 +36,8 @@ final class MyPageAnalyticsManager {
         case termsOfUse = "terms_of_use"
         case privacyPolicy = "privacy_policy"
         case creator = "creator"
+        case insta = "insta"
+        case languageSetting = "language_setting"
         case logout = "logout"
         case withdraw = "withdraw"
     }

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/LoginViewController.swift
@@ -130,6 +130,8 @@ final class LoginViewController: BaseViewController {
                 )
 
             }
+            // 로그인 성공 + 유저 정보 채운 뒤 식별
+            AnalyticsIdentityManager.identify()
             changeIntoHomeViewController()
         } else {
             // 닉네임 설정이 필요한 경우

--- a/EATSSU/App/Sources/Presentation/Auth/ViewController/SetNickNameViewController.swift
+++ b/EATSSU/App/Sources/Presentation/Auth/ViewController/SetNickNameViewController.swift
@@ -363,6 +363,8 @@ extension SetNickNameViewController {
                                                             departmentId: departmentInfo.id,
                                                             departmentName: departmentInfo.name)
                 }
+                // 학과 정보 갱신 후 유저 속성 재식별
+                AnalyticsIdentityManager.identify()
                 completion(true)
                 
             case .failure(let error):

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/LanguageSettingViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/LanguageSettingViewController.swift
@@ -122,6 +122,8 @@ final class LanguageSettingViewController: BaseViewController {
         AppLanguageManager.shared.changeLanguage(to: language)
         didChangeLanguage = true
 
+        AnalyticsService.logEvent("change_language", parameters: ["language": language.rawValue])
+
         updateLocalizedTexts()
     }
 

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -115,8 +115,9 @@ final class MyPageViewController: BaseViewController {
         let fixAction = UIAlertAction(title: TextLiteral.MyPage.logout,
                                       style: .default,
                                       handler: { _ in
+            AnalyticsIdentityManager.reset()
             RealmService.shared.resetDB()
-            
+
             let loginViewController = LoginViewController()
             if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow })

--- a/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
+++ b/EATSSU/App/Sources/Presentation/MyPage/ViewController/MyPageViewController.swift
@@ -307,12 +307,14 @@ extension MyPageViewController: UITableViewDelegate {
 
         // "EAT-SSU 인스타그램" 외부 링크 열기
         case .instagram:
+            MyPageAnalyticsManager.shared.logClickMyPageMenu(menu: .insta)
             if let instagramURL = URL(string: URLConstants.instagram) {
                 UIApplication.shared.open(instagramURL)
             }
 
         // "언어 설정" 스크린으로 이동
         case .languageSetting:
+            MyPageAnalyticsManager.shared.logClickMyPageMenu(menu: .languageSetting)
             let languageSettingViewController = LanguageSettingViewController()
             navigationController?.pushViewController(languageSettingViewController, animated: true)
 

--- a/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/AppDelegate.swift
@@ -97,7 +97,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 
         let config = PostHogConfig(apiKey: apiKey, host: "https://us.i.posthog.com")
         config.captureApplicationLifecycleEvents = true
-        // 수동 .screen() 호출(AnalyticsService.logScreen)과 중복되므로 자동수집은 비활성화
+        // 수동 screen_view 발사(AnalyticsService.logScreen)와 중복되므로 자동수집은 비활성화
         config.captureScreenViews = false
 
         PostHogSDK.shared.setup(config)

--- a/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
+++ b/EATSSU/App/Sources/Utility/Application/SceneDelegate.swift
@@ -276,6 +276,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             await MainActor.run {
                 switch result {
                 case .authenticated:
+                    // 이미 로그인된 유저도 앱 실행 시 식별
+                    AnalyticsIdentityManager.identify()
                     transitionToHome()
                 case .notAuthenticated, .sessionExpired:
                     transitionToLogin(withMessage: result.errorMessage)

--- a/EATSSU/App/Sources/Utility/Helper/KeychainHelper.swift
+++ b/EATSSU/App/Sources/Utility/Helper/KeychainHelper.swift
@@ -1,0 +1,50 @@
+//
+//  KeychainHelper.swift
+//  EATSSU
+//
+//  Created by 황상환 on 7/4/26.
+//
+
+import Foundation
+import Security
+
+/// 문자열 값을 Keychain에 저장/조회하는 최소 헬퍼.
+/// UserDefaults와 달리 앱 재설치 후에도 값이 유지된다.
+enum KeychainHelper {
+
+    /// 값을 저장한다. 같은 key가 있으면 덮어쓴다.
+    @discardableResult
+    static func save(_ value: String, forKey key: String) -> Bool {
+        guard let data = value.data(using: .utf8) else { return false }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key
+        ]
+        SecItemDelete(query as CFDictionary)
+
+        var attributes = query
+        attributes[kSecValueData as String] = data
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+
+        return SecItemAdd(attributes as CFDictionary, nil) == errSecSuccess
+    }
+
+    /// 값을 조회한다. 없으면 nil.
+    static func read(forKey key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return value
+    }
+}

--- a/EATSSU/App/Sources/Utility/Helper/KeychainHelper.swift
+++ b/EATSSU/App/Sources/Utility/Helper/KeychainHelper.swift
@@ -12,6 +12,9 @@ import Security
 /// UserDefaults와 달리 앱 재설치 후에도 값이 유지된다.
 enum KeychainHelper {
 
+    /// kSecAttrAccount와 함께 복합 기본 키를 구성해 다른 항목과의 충돌을 방지한다.
+    private static let service = Bundle.main.bundleIdentifier ?? "com.eatssu.keychain"
+
     /// 값을 저장한다. 같은 key가 있으면 덮어쓴다.
     @discardableResult
     static func save(_ value: String, forKey key: String) -> Bool {
@@ -19,7 +22,8 @@ enum KeychainHelper {
 
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: key
+            kSecAttrAccount as String: key,
+            kSecAttrService as String: service
         ]
         SecItemDelete(query as CFDictionary)
 
@@ -35,6 +39,7 @@ enum KeychainHelper {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: key,
+            kSecAttrService as String: service,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]


### PR DESCRIPTION
### #️⃣ 관련 이슈

Resolved #429

### 💡작업 내용
> Firebase / PostHog 이벤트 추가 설계 및 유저 식별(identify) 구현

**노션 이벤트 체크리스트 4건**
- `app_launch` 이벤트에 `app_locale`(앱 내 설정 언어 `ko`/`en`) 파라미터 추가
- PostHog 화면 조회를 네이티브 `.screen()`(`$screen`) 대신 `screen_view` 커스텀 이벤트로 통일 (Firebase와 이벤트명 일치)
- 앱 내 언어 설정 변경 시 `change_language` 이벤트 발사 (실제로 언어가 바뀐 경우만)
- `click_mypage_menu`의 `menu` 파라미터에 `insta` / `language_setting` 값 추가

**유저 식별(identify) 구현**
- iOS는 로그인 시 이메일을 안정적으로 확보할 수 없어(애플은 최초 1회만 제공), 이메일 대신 **기기 단위 UUID**를 식별자로 사용
- UUID는 **Keychain에 저장**하여 로그아웃/재설치 후에도 유지 → PostHog `identify` / Firebase `setUserID`에 공통 사용
- 유저 속성으로 `provider`(kakao/apple), `college_id`/`college_name`, `department_id`/`department_name` 전송 (이메일 등 PII 미전송)
- 연결 지점: **앱 실행(로그인 상태) / 로그인 성공 / 학과 갱신 → `identify`**, **로그아웃 → `reset`**
- Realm 스키마 변경 없음 → **DB 마이그레이션 불필요**

### 💬리뷰 요구사항(선택)
- 유저 식별은 **기기 단위**라 동일인의 크로스 디바이스/안드로이드 통합은 불가합니다. 추후 백엔드가 고유 memberId를 내려주면 UUID를 그 값으로 교체만 하면 됩니다. (DA 임도빈님과 협의된 방향)
- `AnalyticsIdentityManager.identify()`에 DEBUG 전용 로그(`👤 [Identify] ...`)를 남겨 UUID/속성 조립을 콘솔에서 확인할 수 있게 해두었습니다.
